### PR TITLE
Fix: ajustar cálculo de FIELD_LEN para VARCHAR no MySQL 8.x

### DIFF
--- a/source/mysql.c
+++ b/source/mysql.c
@@ -662,8 +662,21 @@ HB_FUNC(MYSQUERYATTR)
     case MYSQL_VAR_STRING_TYPE:
       // case MYSQL_DATETIME_TYPE:
 
-      hb_arraySetForward(atemp, FIELD_TYPE, hb_itemPutC(temp, "C"));
-      hb_arraySetForward(atemp, FIELD_LEN, hb_itemPutNI(temp, (int)field->length));
+      hb_itemPutC(temp, "C");
+
+      MY_CHARSET_INFO cs;
+      unsigned int mbmax = 1;
+
+      mysql_get_character_set_info(session->dbh, &cs); 
+      if (cs.mbmaxlen > 0)
+        mbmax = (unsigned int) cs.mbmaxlen;
+
+      int char_len = (int) ((mbmax > 1) ? (field->length / mbmax) : field->length);
+      if (char_len <= 0)
+        char_len = (int) field->length;
+
+      hb_arraySetForward(atemp, FIELD_TYPE, temp);
+      hb_arraySetForward(atemp, FIELD_LEN, hb_itemPutNI(temp, char_len));
       hb_arraySetForward(atemp, FIELD_DEC, hb_itemPutNI(temp, 0));
       hb_arraySetForward(atemp, FIELD_DOMAIN, hb_itemPutNI(temp, SQL_CHAR));
       break;
@@ -802,8 +815,20 @@ HB_FUNC(MYSTABLEATTR)
     case MYSQL_VAR_STRING_TYPE:
       // case MYSQL_DATETIME_TYPE:
       hb_itemPutC(temp, "C");
+      
+      MY_CHARSET_INFO cs;
+      unsigned int mbmax = 1;
+
+      mysql_get_character_set_info(session->dbh, &cs); 
+      if (cs.mbmaxlen > 0)
+        mbmax = (unsigned int) cs.mbmaxlen;
+
+      int char_len = (int) ((mbmax > 1) ? (field->length / mbmax) : field->length);
+      if (char_len <= 0)
+        char_len = (int) field->length;
+      
       hb_arraySetForward(atemp, FIELD_TYPE, temp);
-      hb_arraySetForward(atemp, FIELD_LEN, hb_itemPutNI(temp, (int)field->length));
+      hb_arraySetForward(atemp, FIELD_LEN, hb_itemPutNI(temp, char_len));
       hb_arraySetForward(atemp, FIELD_DEC, hb_itemPutNI(temp, 0));
       hb_arraySetForward(atemp, FIELD_DOMAIN, hb_itemPutNI(temp, SQL_CHAR));
       break;


### PR DESCRIPTION
No MySQL 8.x, MYSQL_FIELD.length para VARCHAR(n) retorna tamanho em bytes
(n * mbmaxlen, ex.: utf8mb4 → 4 bytes por char). Isso fazia com que VARCHAR(5)
fosse interpretado como 20 e VARCHAR(30) como 120.

Ajuste: dividir field->length por mbmaxlen da conexão (mysql_get_character_set_info).
Fallback para field->length se mbmaxlen for inválido ou divisão der 0.

Impacto: MYSQUERYATTR e MYSTABLEATTR agora retornam corretamente o tamanho
em caracteres para campos VARCHAR, evitando metadados inconsistentes.