### PR TITLE
fix(pgs): silence 'there is no transaction in progress' warnings

### DIFF
--- a/source/postgresql/sr_pgs.prg
+++ b/source/postgresql/sr_pgs.prg
@@ -317,6 +317,14 @@ METHOD SR_PGS:ConnectRaw(cDSN, cUser, cPassword, nVersion, cOwner, nSizeMaxBuff,
       ::uSid := Val(Str(aRet[1, 1], 8, 0))
    ENDIF
 
+   /* Open initial transaction block. The rest of SQLRDD assumes the connection
+      is always inside a transaction (since Commit/RollBack emit COMMIT;BEGIN and
+      BEGIN respectively). Without this initial BEGIN, the very first Commit()
+      after connect would trigger "there is no transaction in progress". */
+   IF !Empty(::nSystemID)
+      ::Exec("BEGIN", .F.)
+   ENDIF
+
 RETURN Self
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -340,17 +348,58 @@ RETURN NIL
 
 METHOD SR_PGS:Commit(lNoLog)
 
+   LOCAL nStat
+
    ::Super:Commit(lNoLog)
 
-RETURN (::nRetCode := ::Exec("COMMIT;BEGIN", .F.))
+   /* PostgreSQL emits the warning "there is no transaction in progress"
+      whenever COMMIT/ROLLBACK is sent while the backend is not inside a
+      transaction block. PQtransactionStatus() is available since libpq 7.3,
+      so this check is safe for every supported server version (8.0+).
+        PQTRANS_IDLE    (0) - no transaction; only BEGIN, no COMMIT
+        PQTRANS_INTRANS (2) - clean transaction; COMMIT then BEGIN
+        PQTRANS_INERROR (3) - failed transaction; must ROLLBACK, then BEGIN
+        PQTRANS_ACTIVE  (1) / PQTRANS_UNKNOWN (4) - leave it alone
+   */
+   nStat := SR_PGSTransStatus(::hDbc)
+
+   DO CASE
+   CASE nStat == 0   // PQTRANS_IDLE
+      ::nRetCode := ::Exec("BEGIN", .F.)
+   CASE nStat == 2   // PQTRANS_INTRANS
+      ::nRetCode := ::Exec("COMMIT;BEGIN", .F.)
+   CASE nStat == 3   // PQTRANS_INERROR
+      ::nRetCode := ::Exec("ROLLBACK;BEGIN", .F.)
+   OTHERWISE
+      // PQTRANS_ACTIVE or PQTRANS_UNKNOWN: do not interfere
+      ::nRetCode := SQL_SUCCESS
+   ENDCASE
+
+RETURN ::nRetCode
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 METHOD SR_PGS:RollBack()
 
+   LOCAL nStat
+
    ::Super:RollBack()
-   ::nRetCode := SR_PGSRollBack(::hDbc)
-   ::Exec("BEGIN", .F.)
+
+   nStat := SR_PGSTransStatus(::hDbc)
+
+   /* Only issue ROLLBACK if there is actually a transaction to roll back.
+      Then reopen with BEGIN so the connection remains inside a transaction
+      block as the rest of SQLRDD expects. */
+   IF nStat == 2 .OR. nStat == 3   // INTRANS or INERROR
+      ::nRetCode := SR_PGSRollBack(::hDbc)
+   ELSE
+      ::nRetCode := SQL_SUCCESS
+   ENDIF
+
+   /* Open a fresh transaction only if we are now idle */
+   IF SR_PGSTransStatus(::hDbc) == 0   // PQTRANS_IDLE
+      ::Exec("BEGIN", .F.)
+   ENDIF
 
 RETURN ::nRetCode
 

--- a/source/postgresql/sr_pgs_bind.c
+++ b/source/postgresql/sr_pgs_bind.c
@@ -363,6 +363,24 @@ HB_FUNC_STATIC(SR_PGSROLLBACK)
   }
 }
 
+// SR_PGSTransStatus(ConnHandle) => nStatus
+// Returns PQtransactionStatus() result. Available in libpq since PostgreSQL 7.3,
+// so it is safe to use across the entire range of supported server versions (8.0+).
+//   0 = PQTRANS_IDLE    (no transaction open)
+//   1 = PQTRANS_ACTIVE  (query in progress)
+//   2 = PQTRANS_INTRANS (idle, inside a transaction block)
+//   3 = PQTRANS_INERROR (inside a failed transaction block)
+//   4 = PQTRANS_UNKNOWN (connection is bad)
+HB_FUNC_STATIC(SR_PGSTRANSSTATUS)
+{
+  GET_PGSQL_SESSION(session, 1);
+  if (session == SR_NULLPTR || session->dbh == SR_NULLPTR) {
+    hb_retni(4); // PQTRANS_UNKNOWN
+    return;
+  }
+  hb_retni((int)PQtransactionStatus(session->dbh));
+}
+
 // SR_PGSQueryAttr(ResultSet) => aStruct
 HB_FUNC_STATIC(SR_PGSQUERYATTR)
 {


### PR DESCRIPTION
fix(pgs): silence "there is no transaction in progress" warnings

PostgreSQL emits a WARNING whenever COMMIT or ROLLBACK is sent while
the backend is not inside a transaction block. SR_PGS:Commit() sent
"COMMIT;BEGIN" unconditionally and ConnectRaw never emitted an initial
BEGIN, so the first Commit() after connecting always triggered the
warning, as did any Commit() following an implicit transaction abort.

Use PQtransactionStatus() (available in libpq since PostgreSQL 7.3,
so compatible with every supported server version 8.0+) to decide
which command to send based on the actual backend state:

  - IDLE    -> only BEGIN
  - INTRANS -> COMMIT/ROLLBACK then BEGIN
  - INERROR -> ROLLBACK then BEGIN
  - ACTIVE / UNKNOWN -> leave the connection alone

Changes:
  - sr_pgs_bind.c: expose PQtransactionStatus via SR_PGSTRANSSTATUS
  - sr_pgs.prg: rewrite Commit() and RollBack() with state-aware logic
  - sr_pgs.prg: emit initial BEGIN at the end of ConnectRaw

Fixes recurring warnings in PostgreSQL server log:
  WARNING: there is no transaction in progress