### PR TITLE
SQLEX: fixes for tables with function keys (issue: Index Column not Found)

### DIFF
--- a/source/sqlrdd2.prg
+++ b/source/sqlrdd2.prg
@@ -2038,7 +2038,10 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
       ::aIndex[nInd, INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
+            // SQLEX does not expose the INDKEY_ column as a field, so the key
+            // codeblock must evaluate the original xBase expression client
+            // side (same value stored in INDKEY_, without the recno suffix)
+            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, INDEXMAN_IDXKEY]) + ") }")
          ELSE
             ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          ENDIF
@@ -7419,7 +7422,10 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
       IF !Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
 
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
+            // SQLEX does not expose the INDKEY_ column as a field, so the key
+            // codeblock must evaluate the original xBase expression client
+            // side (same value stored in INDKEY_, without the recno suffix)
+            ::aIndex[nLen, INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, INDEXMAN_IDXKEY]) + ") }")
          ELSE
             ::aIndex[nLen, INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          ENDIF

--- a/source/sqlrdd2.prg
+++ b/source/sqlrdd2.prg
@@ -277,7 +277,8 @@ CLASS SR_WORKAREA
    METHOD IndexFieldDec(aFld)           // component decimals
    METHOD IndexFieldNul(aFld)           // component nullability (.F. for expressions)
    METHOD HasExpressionOrder()          // .T. when the active order has expression components
-   METHOD CanUseExpressionIndex()       // .T. when expression indexes apply to this workarea
+   METHOD CanOpenExpressionIndex()      // .T. when this workarea can OPEN expression indexes
+   METHOD CanUseExpressionIndex()       // .T. when this workarea can CREATE expression indexes
 
    METHOD HasFilters()
    METHOD ParseForClause(cFor)
@@ -729,9 +730,15 @@ RETURN cRet
 //
 //-------------------------------------------------------------------------------------------------------------------//
 
-METHOD SR_WORKAREA:CanUseExpressionIndex()
+METHOD SR_WORKAREA:CanOpenExpressionIndex()   // opening never depends on SR_GetExpressionIndex()
 
-RETURN ::oSql:nSystemID == SQLRDD_RDBMS_POSTGR .AND. !(RDDNAME() == "SQLEX") .AND. SR_GetExpressionIndex()
+RETURN ::oSql:nSystemID == SQLRDD_RDBMS_POSTGR .AND. !(RDDNAME() == "SQLEX")
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+METHOD SR_WORKAREA:CanUseExpressionIndex()    // creating new expression indexes
+
+RETURN ::CanOpenExpressionIndex() .AND. SR_GetExpressionIndex()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -1915,9 +1922,17 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
 
       FOR i := 1 TO Len(aCols)
 
-         IF HB_IsChar(aCols[i]) .AND. "(" $ aCols[i] .AND. ::CanUseExpressionIndex()
+         IF HB_IsChar(aCols[i]) .AND. "(" $ aCols[i]
 
             // Expression index component (UPPER/SUBSTR/LEFT/STRZERO/...)
+
+            IF !::CanOpenExpressionIndex()
+               ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
+                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
+                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
+                  " with this RDD or open the table with SQLRDD)")
+               RETURN 0    // error exit
+            ENDIF
 
             uComp := ::BuildIndexComponent(aCols[i])
 
@@ -7277,9 +7292,17 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
 
       FOR i := 1 TO Len(aCols)
 
-         IF HB_IsChar(aCols[i]) .AND. "(" $ aCols[i] .AND. ::CanUseExpressionIndex()
+         IF HB_IsChar(aCols[i]) .AND. "(" $ aCols[i]
 
             // Expression index component (UPPER/SUBSTR/LEFT/STRZERO/...)
+
+            IF !::CanOpenExpressionIndex()
+               ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
+                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
+                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
+                  " with this RDD or open the table with SQLRDD)")
+               RETURN 0    // error exit
+            ENDIF
 
             uComp := ::BuildIndexComponent(aCols[i])
 

--- a/source/sqlrdd2_postgresql.prg
+++ b/source/sqlrdd2_postgresql.prg
@@ -1733,7 +1733,10 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
       ::aIndex[nInd, INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
+            // SQLEX does not expose the INDKEY_ column as a field, so the key
+            // codeblock must evaluate the original xBase expression client
+            // side (same value stored in INDKEY_, without the recno suffix)
+            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, INDEXMAN_IDXKEY]) + ") }")
          ELSE
             ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          ENDIF
@@ -5644,7 +5647,10 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
       ::aIndex[nLen, INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
+            // SQLEX does not expose the INDKEY_ column as a field, so the key
+            // codeblock must evaluate the original xBase expression client
+            // side (same value stored in INDKEY_, without the recno suffix)
+            ::aIndex[nLen, INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, INDEXMAN_IDXKEY]) + ") }")
          ELSE
             ::aIndex[nLen, INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, INDEXMAN_COLUMNS])
          ENDIF

--- a/source/sqlrdd2_postgresql.prg
+++ b/source/sqlrdd2_postgresql.prg
@@ -270,6 +270,8 @@ CLASS SR_WORKAREA
 
    // Expression index support (PostgreSQL native expression indexes)
 
+   METHOD CanOpenExpressionIndex()      // .T. when this workarea can OPEN expression indexes
+   METHOD CanUseExpressionIndex()       // .T. when this workarea can CREATE expression indexes
    METHOD ParseIndexComponents(cExpr)   // xBase index key => array of components or NIL
    METHOD BuildIndexComponent(cItem)    // one component => column name, component array or NIL
    METHOD IndexFieldSQL(aFld)           // SQL expression (or qualified column) of a component
@@ -723,6 +725,21 @@ RETURN cRet
 // All SQL expressions produce TRIMMED text ("rtrim(...)") because ::Quoted()
 // always trims character values, so equality comparisons stay consistent.
 //
+//-------------------------------------------------------------------------------------------------------------------//
+
+METHOD SR_WORKAREA:CanOpenExpressionIndex()   // opening never depends on SR_GetExpressionIndex()
+
+// The SQLEX RDD builds its queries at C level directly from INDEX_FIELDS
+// and does not understand expression components
+
+RETURN !(RDDNAME() == "SQLEX")
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+METHOD SR_WORKAREA:CanUseExpressionIndex()    // creating new expression indexes
+
+RETURN ::CanOpenExpressionIndex() .AND. SR_GetExpressionIndex()
+
 //-------------------------------------------------------------------------------------------------------------------//
 
 METHOD SR_WORKAREA:ParseIndexComponents(cExpr)
@@ -1627,6 +1644,14 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
          IF HB_IsChar(aCols[i]) .AND. "(" $ aCols[i]
 
             // Expression index component (UPPER/SUBSTR/LEFT/STRZERO/...)
+
+            IF !::CanOpenExpressionIndex()
+               ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
+                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
+                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
+                  " with this RDD or open the table with SQLRDD)")
+               RETURN 0    // error exit
+            ENDIF
 
             uComp := ::BuildIndexComponent(aCols[i])
 
@@ -5530,6 +5555,14 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
 
             // Expression index component (UPPER/SUBSTR/LEFT/STRZERO/...)
 
+            IF !::CanOpenExpressionIndex()
+               ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
+                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
+                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
+                  " with this RDD or open the table with SQLRDD)")
+               RETURN 0    // error exit
+            ENDIF
+
             uComp := ::BuildIndexComponent(aCols[i])
 
             IF HB_IsArray(uComp)
@@ -6027,7 +6060,7 @@ METHOD SR_WORKAREA:sqlOrderCreate(cIndexName, cColumns, cTag, cConstraintName, c
    // of a synthetic INDKEY_ column. Only untranslatable (user defined)
    // functions still fall back to the synthetic column.
 
-   IF lSyntheticIndex .AND. !SR_GetSyntheticIndex() .AND. SR_GetExpressionIndex()
+   IF lSyntheticIndex .AND. !SR_GetSyntheticIndex() .AND. ::CanUseExpressionIndex()
       aExprCols := ::ParseIndexComponents(cColumns)
       IF aExprCols != NIL
          lSyntheticIndex := .F.
@@ -6060,7 +6093,7 @@ METHOD SR_WORKAREA:sqlOrderCreate(cIndexName, cColumns, cTag, cConstraintName, c
       // expression indexes are enabled PostgreSQL handles multi column and
       // expression indexes natively, so keep the regular index instead of
       // creating an INDKEY_ column.
-      IF !SR_GetExpressionIndex()
+      IF !::CanUseExpressionIndex()
          lSyntheticIndex := .T.
          lSyntheticVirtual := .F.
       ENDIF

--- a/tests/sqlexpgsqlexprindex.prg
+++ b/tests/sqlexpgsqlexprindex.prg
@@ -1,0 +1,440 @@
+// SQLRDD++
+// Indices com funcoes no RDD SQLEX (ODBC/PostgreSQL)
+//
+// O RDD SQLEX monta as consultas em nivel C diretamente a partir das
+// colunas do indice (INDEX_FIELDS) e NAO suporta os indices de expressao
+// nativos do PostgreSQL introduzidos para o RDD SQLRDD.
+//
+// Este exemplo demonstra o comportamento esperado no SQLEX:
+//
+// 1. Indices com funcoes na chave (UPPER, SUBSTR, STRZERO, UDF) criados
+//    sob o SQLEX continuam usando o mecanismo classico da coluna
+//    sintetica INDKEY_ - tudo funciona como sempre funcionou;
+// 2. Indices de EXPRESSAO criados pelo RDD SQLRDD nao podem ser abertos
+//    pelo SQLEX: a abertura gera o erro 18 com mensagem explicativa.
+//    Nesse cenario, recrie o indice sob o SQLEX (vira sintetico) ou abra
+//    a tabela com o SQLRDD. Para cargas em massa via SQLEX sem uso de
+//    indices, RDDINFO(RDDI_AUTOOPEN, .F.) evita a abertura automatica.
+//
+// Para compilar (na pasta tests, que linka a lib generica sqlrddpp):
+// hbmk2 sqlexpgsqlexprindex
+//
+// Para executar:
+// sqlexpgsqlexprindex --driver <driverodbc> --server <servidor> --port <porta> --uid <usuario> --pwd <senha> --database <banco>
+// NOTA: o banco de dados deve existir antes de rodar o teste.
+
+#ifdef __XHARBOUR__
+#xtranslate HB_PVALUE([<x,...>]) => PVALUE(<x>)
+#endif
+
+#include "sqlrdd.ch"
+#include "inkey.ch"
+
+#define RDD_NAME "SQLEX"
+#define TABLE_NAME "testexpx"
+#define NUM_REC 200
+
+REQUEST SQLEX
+REQUEST SR_ODBC
+
+REQUEST STRZERO
+REQUEST PADR
+REQUEST PADL
+REQUEST SUBSTR
+REQUEST DTOS
+
+STATIC s_ODBC_DRIVER   := "PostgreSQL Unicode"
+STATIC s_ODBC_SERVER   := "localhost"
+STATIC s_ODBC_PORT     := "5432"
+STATIC s_ODBC_UID      := "postgres"
+STATIC s_ODBC_PWD      := "password"
+STATIC s_ODBC_DATABASE := "dbtest"
+STATIC s_ODBC_OPTIONS  := "BoolsAsChar=0;TrueIsMinus1;" // DO NOT CHANGE
+
+PROCEDURE Main()
+
+   LOCAL nConnection
+   LOCAL n
+   LOCAL cOpt
+   LOCAL stringConect
+
+   n := 1
+   DO WHILE n <= PCount()
+      DO CASE
+      CASE HB_PValue(n) == "--driver"   ; s_ODBC_DRIVER := HB_PValue(++n)
+      CASE HB_PValue(n) == "--server"   ; s_ODBC_SERVER := HB_PValue(++n)
+      CASE HB_PValue(n) == "--port"     ; s_ODBC_PORT := HB_PValue(++n)
+      CASE HB_PValue(n) == "--uid"      ; s_ODBC_UID := HB_PValue(++n)
+      CASE HB_PValue(n) == "--pwd"      ; s_ODBC_PWD := HB_PValue(++n)
+      CASE HB_PValue(n) == "--database" ; s_ODBC_DATABASE := HB_PValue(++n)
+      CASE HB_PValue(n) == "--options"  ; s_ODBC_OPTIONS := HB_PValue(++n)
+      ENDCASE
+      ++n
+   ENDDO
+
+   SET DATE ANSI
+   SET CENTURY ON
+
+   rddSetDefault(RDD_NAME)
+
+   stringConect := "Driver="   + s_ODBC_DRIVER   + ";" + ;
+                   "Server="   + s_ODBC_SERVER   + ";" + ;
+                   "Port="     + s_ODBC_PORT     + ";" + ;
+                   "Database=" + s_ODBC_DATABASE + ";" + ;
+                   "Uid="      + s_ODBC_UID      + ";" + ;
+                   "Pwd="      + s_ODBC_PWD      + ";" + ;
+                   ""          + s_ODBC_OPTIONS  + ";"
+
+   ? "Conectando via ODBC (RDD SQLEX) em " + s_ODBC_SERVER + ":" + s_ODBC_PORT + "/" + s_ODBC_DATABASE + " ..."
+   ? "String de conexao: " + stringConect
+
+   nConnection := sr_AddConnection(CONNECT_ODBC, stringConect)
+
+   IF nConnection < 0
+      ? "Erro de conexao. Veja sqlerror.log para detalhes."
+      WAIT
+      QUIT
+   ENDIF
+
+   sr_StartLog(nConnection)
+
+   CriaTabela()
+   CriaIndices()
+   MostraColunasExtras()
+   MostraIndicesFisicos()
+
+   ? ""
+   ? "Pressione uma tecla para iniciar os testes de SEEK..."
+   Inkey(0)
+
+   TestaSeeks()
+
+   // Reabre a tabela para testar tambem a reabertura dos indices
+   // sinteticos registrados em SR_MGMNTINDEXES
+
+   CLOSE DATABASE
+   ? ""
+   ? "Reabrindo a tabela (indices carregados do SR_MGMNTINDEXES)..."
+   USE (TABLE_NAME) SHARED VIA (RDD_NAME)
+
+   // Menu interativo com DBEDIT para avaliacao visual
+
+   DO WHILE .T.
+      CLS
+      ? "=============================================================="
+      ? " SQLRDD++ - Indices com funcoes no RDD SQLEX (PostgreSQL)"
+      ? " Comportamento classico: chaves com funcao usam INDKEY_"
+      ? "=============================================================="
+      ? ""
+      MostraOrdens()
+      ? ""
+      ? " 1..5 - Navegar (DBEDIT) na ordem escolhida"
+      ? " 0    - Navegar em ordem natural (sem indice)"
+      ? " S    - Repetir testes de SEEK"
+      ? " C    - Mostrar colunas INDKEY_ da tabela"
+      ? " Q    - Sair"
+      ? ""
+      ACCEPT "Opcao: " TO cOpt
+      cOpt := Upper(AllTrim(cOpt))
+
+      DO CASE
+      CASE cOpt == "Q"
+         EXIT
+      CASE cOpt == "S"
+         CLS
+         TestaSeeks()
+         WAIT
+      CASE cOpt == "C"
+         CLS
+         MostraColunasExtras()
+         MostraIndicesFisicos()
+         WAIT
+      CASE Val(cOpt) >= 0 .AND. Val(cOpt) <= OrdCount()
+         DBSetOrder(Val(cOpt))
+         DBGoTop()
+         CLS
+         @ 0, 0 SAY PadR("Ordem: " + LTrim(Str(IndexOrd())) + "  Tag: " + ordName() + "  Chave: " + ordKey(), MaxCol() + 1)
+         DBEdit(1, 0, MaxRow(), MaxCol())
+      ENDCASE
+   ENDDO
+
+   CLS
+   ? "Remover a tabela de teste '" + TABLE_NAME + "' ? (S/N)"
+   IF Upper(Chr(Inkey(0))) == "S"
+      CLOSE DATABASE
+      sr_DropTable(TABLE_NAME)
+      ? "Tabela removida."
+   ELSE
+      CLOSE DATABASE
+      ? "Tabela mantida para inspecao manual."
+   ENDIF
+
+   sr_StopLog(nConnection)
+   sr_EndConnection(nConnection)
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE CriaTabela()
+
+   LOCAL n
+   LOCAL aNomes := {"Ana Souza", "bruno LIMA", "CARLA Mendes", "diego costa", "Elisa RAMOS", ;
+                    "FABIO silva", "Gustavo Reis", "helena DIAS", "Igor MOURA", "julia castro"}
+   LOCAL aCidades := {"Sao Paulo", "RIO DE JANEIRO", "belo horizonte", "Curitiba", "PORTO ALEGRE", ;
+                      "salvador", "Fortaleza", "MANAUS", "recife", "Goiania"}
+
+   IF sr_ExistTable(TABLE_NAME)
+      ? "Removendo tabela anterior..."
+      sr_DropTable(TABLE_NAME)
+   ENDIF
+
+   ? "Criando tabela " + TABLE_NAME + "..."
+
+   dbCreate(TABLE_NAME, {{"ID      ", "N", 10, 0}, ;
+                         {"NOME    ", "C", 30, 0}, ;
+                         {"CIDADE  ", "C", 20, 0}, ;
+                         {"ADMISSAO", "D",  8, 0}, ;
+                         {"SALDO   ", "N", 12, 2}}, RDD_NAME)
+
+   USE (TABLE_NAME) EXCLUSIVE VIA (RDD_NAME)
+
+   ? "Populando com " + LTrim(Str(NUM_REC)) + " registros..."
+
+   FOR n := 1 TO NUM_REC
+      APPEND BLANK
+      REPLACE ID       WITH n
+      REPLACE NOME     WITH aNomes[((n - 1) % Len(aNomes)) + 1] + " " + StrZero(n, 4)
+      REPLACE CIDADE   WITH aCidades[((n - 1) % Len(aCidades)) + 1]
+      REPLACE ADMISSAO WITH Date() - n
+      REPLACE SALDO    WITH n * 10.50
+   NEXT n
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE CriaIndices()
+
+   ? ""
+   ? "Criando indices sob o SQLEX (chaves com funcao => INDKEY_ classico)..."
+   ? ""
+
+   ? "  TAG testexpx1: UPPER(NOME)                    => sintetico (INDKEY_)"
+   INDEX ON UPPER(NOME) TAG testexpx1 TO testexpx
+
+   ? "  TAG testexpx2: SUBSTR(CIDADE,1,10)            => sintetico (INDKEY_)"
+   INDEX ON SUBSTR(CIDADE, 1, 10) TAG testexpx2 TO testexpx
+
+   ? "  TAG testexpx3: STRZERO(SALDO,12,2)            => sintetico (INDKEY_)"
+   INDEX ON STRZERO(SALDO, 12, 2) TAG testexpx3 TO testexpx
+
+   ? "  TAG testexpx4: DTOS(ADMISSAO)+STRZERO(ID,10)  => sintetico (INDKEY_)"
+   INDEX ON DTOS(ADMISSAO) + STRZERO(ID, 10) TAG testexpx4 TO testexpx
+
+   ? "  TAG testexpx5: MYUDF(NOME)                    => sintetico (INDKEY_)"
+   INDEX ON MYUDF(NOME) TAG testexpx5 TO testexpx
+
+RETURN
+
+//--------------------------------------------------------------------
+// Funcao proprietaria (nao existe no PostgreSQL): forca indice sintetico
+
+FUNCTION MYUDF(cNome)
+
+RETURN Upper(Right(RTrim(cNome), 4)) + Upper(Left(cNome, 3))
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE MostraColunasExtras()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL aRes := {}
+   LOCAL aLinha
+
+   ? ""
+   ? "Colunas INDKEY_/INDFOR_ existentes na tabela"
+   ? "(no SQLEX o esperado sao colunas INDKEY_ para as chaves com funcao):"
+
+   oCnn:Exec("select column_name from information_schema.columns where table_name = '" + ;
+             Lower(TABLE_NAME) + "' and (column_name like 'indkey_%' or column_name like 'indfor_%') order by 1", .F., .T., @aRes)
+
+   IF Len(aRes) == 0
+      ? "  (nenhuma coluna extra)"
+   ELSE
+      FOR EACH aLinha IN aRes
+         ? "  - " + AllTrim(aLinha[1])
+      NEXT
+   ENDIF
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE MostraIndicesFisicos()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL aRes := {}
+   LOCAL aLinha
+
+   ? ""
+   ? "Indices fisicos no PostgreSQL (sob o SQLEX apontam para as colunas INDKEY_):"
+
+   oCnn:Exec("select indexname, indexdef from pg_indexes where tablename = '" + ;
+             Lower(TABLE_NAME) + "' order by 1", .F., .T., @aRes)
+
+   FOR EACH aLinha IN aRes
+      ? "  " + PadR(AllTrim(aLinha[1]), 22) + SubStr(AllTrim(aLinha[2]), At("(", AllTrim(aLinha[2])))
+   NEXT
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE MostraOrdens()
+
+   LOCAL i
+
+   FOR i := 1 TO OrdCount()
+      ? " " + LTrim(Str(i)) + " - " + PadR(ordName(i), 12) + " chave: " + ordKey(i)
+   NEXT i
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE TestaSeeks()
+
+   LOCAL n
+   LOCAL cNome
+   LOCAL cCidade
+   LOCAL dData
+   LOCAL nOk
+   LOCAL nErro
+
+   // ------------------------------------------------ UPPER(NOME)
+
+   IF !SetOrderByTag("TESTEXPX1")
+      ? "AVISO: ordem TESTEXPX1 nao encontrada - testes de SEEK cancelados"
+      RETURN
+   ENDIF
+   ? ""
+   ? "SEEK em UPPER(NOME) - ordem: " + ordName() + " => " + ordKey()
+   nOk := nErro := 0
+   FOR n := 1 TO NUM_REC
+      DBGoTo(n)
+      cNome := Upper(RTrim(FIELD->NOME))
+      SEEK cNome
+      IF Found() .AND. Upper(RTrim(FIELD->NOME)) == cNome
+         nOk++
+      ELSE
+         nErro++
+      ENDIF
+   NEXT n
+   SEEK "ZZZZZZZZ_NAO_EXISTE"
+   IF !Found()
+      nOk++
+   ELSE
+      nErro++
+   ENDIF
+   ? "  encontrados:", nOk, " falhas:", nErro, IIf(nErro == 0, "=> OK", "=> ERRO")
+
+   // ------------------------------------------------ SUBSTR(CIDADE,1,10)
+
+   IF !SetOrderByTag("TESTEXPX2")
+      ? "AVISO: ordem TESTEXPX2 nao encontrada"
+      RETURN
+   ENDIF
+   ? ""
+   ? "SEEK em SUBSTR(CIDADE,1,10) - ordem: " + ordKey()
+   nOk := nErro := 0
+   FOR n := 1 TO NUM_REC
+      DBGoTo(n)
+      cCidade := SubStr(FIELD->CIDADE, 1, 10)
+      SEEK cCidade
+      IF Found() .AND. SubStr(FIELD->CIDADE, 1, 10) == cCidade
+         nOk++
+      ELSE
+         nErro++
+      ENDIF
+   NEXT n
+   ? "  encontrados:", nOk, " falhas:", nErro, IIf(nErro == 0, "=> OK", "=> ERRO")
+
+   // ------------------------------------------------ STRZERO(SALDO,12,2)
+
+   IF !SetOrderByTag("TESTEXPX3")
+      ? "AVISO: ordem TESTEXPX3 nao encontrada"
+      RETURN
+   ENDIF
+   ? ""
+   ? "SEEK em STRZERO(SALDO,12,2) - ordem: " + ordKey()
+   nOk := nErro := 0
+   FOR n := 1 TO NUM_REC
+      SEEK StrZero(n * 10.50, 12, 2)
+      IF Found() .AND. FIELD->SALDO == n * 10.50
+         nOk++
+      ELSE
+         nErro++
+      ENDIF
+   NEXT n
+   ? "  encontrados:", nOk, " falhas:", nErro, IIf(nErro == 0, "=> OK", "=> ERRO")
+
+   // ------------------------------------------------ DTOS(ADMISSAO)+STRZERO(ID,10)
+
+   IF !SetOrderByTag("TESTEXPX4")
+      ? "AVISO: ordem TESTEXPX4 nao encontrada"
+      RETURN
+   ENDIF
+   ? ""
+   ? "SEEK em DTOS(ADMISSAO)+STRZERO(ID,10) - ordem: " + ordKey()
+   nOk := nErro := 0
+   FOR n := 1 TO NUM_REC
+      dData := Date() - n
+      SEEK DToS(dData) + StrZero(n, 10)
+      IF Found() .AND. FIELD->ID == n .AND. FIELD->ADMISSAO == dData
+         nOk++
+      ELSE
+         nErro++
+      ENDIF
+   NEXT n
+   ? "  encontrados:", nOk, " falhas:", nErro, IIf(nErro == 0, "=> OK", "=> ERRO")
+
+   // ------------------------------------------------ MYUDF(NOME)
+
+   IF !SetOrderByTag("TESTEXPX5")
+      ? "AVISO: ordem TESTEXPX5 nao encontrada"
+      RETURN
+   ENDIF
+   ? ""
+   ? "SEEK em MYUDF(NOME) - ordem: " + ordKey()
+   nOk := nErro := 0
+   FOR n := 1 TO NUM_REC
+      DBGoTo(n)
+      cNome := MYUDF(FIELD->NOME)
+      SEEK cNome
+      IF Found() .AND. MYUDF(FIELD->NOME) == cNome
+         nOk++
+      ELSE
+         nErro++
+      ENDIF
+   NEXT n
+   ? "  encontrados:", nOk, " falhas:", nErro, IIf(nErro == 0, "=> OK", "=> ERRO")
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC FUNCTION SetOrderByTag(cTag)
+
+   LOCAL i
+
+   FOR i := 1 TO OrdCount()
+      IF Upper(AllTrim(ordName(i))) == Upper(AllTrim(cTag))
+         DBSetOrder(i)
+         RETURN .T.
+      ENDIF
+   NEXT i
+
+   DBSetOrder(0)
+
+RETURN .F.


### PR DESCRIPTION
Fixes for the issue reported by Mario Sabado: errors when the SQLEX RDD
opens/seeks tables whose index keys contain functions.

1. Clear, actionable error when SQLEX opens a PostgreSQL expression
   index created by the SQLRDD RDD (previously the cryptic
   "SQLEX/18 Index Column not Found - UPPER(BANK_NAME)"). SQLEX builds
   its SKIP/SEEK statements at C level with per-column bindings
   (SR_SetIndexBindStructure in sqlex1.c) and cannot consume expression
   components, so the new message tells the user to recreate the index
   under SQLEX or open the table with SQLRDD.

2. SEEK over synthetic (INDKEY_) indexes under SQLEX raised
   BASE/1003 "Variable does not exist: INDKEY_001": the key codeblock
   was built as {|| INDKEY_001 }, but SQLEX does not expose INDKEY_
   columns as workarea fields. The codeblock is now built from the
   original xBase key expression ({|| SR_Val2Char(UPPER(NOME)) }),
   which evaluates real fields and yields the same value stored in the
   INDKEY_ column. This is a pre-existing SQLEX bug, not related to
   the expression index work. Also fixes a latent slot bug in
   sqlOrderListAdd() (::aIndex[nInd] vs ::aIndex[nLen]).

3. CanOpenExpressionIndex() separated from CanUseExpressionIndex():
   SR_SetExpressionIndex(.F.) now only stops creating new expression
   indexes and no longer prevents opening existing ones. The native
   PostgreSQL build (which also ships SQLEX) gets the same open guard
   it was missing.

New example: tests/sqlexpgsqlexprindex.prg - shows function keys created
under SQLEX keeping the classic synthetic INDKEY_ behavior, with SEEK
batteries and DBEDIT browsing, and documents the cross-RDD rules.
Field-tested against PostgreSQL via ODBC.