### PR TITLE
SQLEX: support PostgreSQL expression indexes in the C SKIP/SEEK engine

### DIFF
--- a/source/sqlex.h
+++ b/source/sqlex.h
@@ -158,24 +158,6 @@ typedef struct _SQL_CHAR_STRUCT
   int size_alloc;
 } SQL_CHAR_STRUCT;
 
-typedef struct _INDEXBIND
-{
-  HB_LONG lFieldPosDB; // Relative field position in aFields
-  HB_LONG hIndexOrder; // Index order
-  int iLevel;          // The current column in index
-  int iIndexColumns;   // How many index columns in index
-  HSTMT SkipFwdStmt;   // Index stmt handle for SQL phrase in this level for FWD movment
-  HSTMT SkipBwdStmt;   // Index stmt handle for SQL phrase in this level for BWD movment
-  HSTMT SeekFwdStmt;   // Index stmt handle for SQL phrase in this level for FWD movment
-  HSTMT SeekBwdStmt;   // Index stmt handle for SQL phrase in this level for BWD movment
-  char SkipFwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
-  char SkipBwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
-  char SeekFwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
-  char SeekBwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
-} INDEXBIND;
-
-typedef INDEXBIND *INDEXBINDP;
-
 typedef struct _COLUMNBIND
 {
   int iParNum;            // Parameter number in binded parameters
@@ -204,6 +186,32 @@ typedef struct _COLUMNBIND
 } COLUMNBIND;
 
 typedef COLUMNBIND *COLUMNBINDP;
+
+typedef struct _INDEXBIND
+{
+  HB_LONG lFieldPosDB; // Relative field position in aFields
+  HB_LONG hIndexOrder; // Index order
+  int iLevel;          // The current column in index
+  int iIndexColumns;   // How many index columns in index
+  HSTMT SkipFwdStmt;   // Index stmt handle for SQL phrase in this level for FWD movment
+  HSTMT SkipBwdStmt;   // Index stmt handle for SQL phrase in this level for BWD movment
+  HSTMT SeekFwdStmt;   // Index stmt handle for SQL phrase in this level for FWD movment
+  HSTMT SeekBwdStmt;   // Index stmt handle for SQL phrase in this level for BWD movment
+  char SkipFwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
+  char SkipBwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
+  char SeekFwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
+  char SeekBwdSql[PREPARED_SQL_LEN]; // Partial prepared query for debugging pourposes
+
+  // Expression index support (PostgreSQL): the component is a SQL
+  // expression over a column instead of the plain column itself
+
+  HB_BOOL bIsExpr;     // Component is an expression index component
+  char *sExprSQL;      // SQL expression to be used instead of the column name
+  PHB_ITEM pExprBlock; // Client side transform codeblock (raw value => key value)
+  COLUMNBIND ExprBind; // Private bind structure (char domain, component length)
+} INDEXBIND;
+
+typedef INDEXBIND *INDEXBINDP;
 
 // SQL WORKAREA
 
@@ -351,6 +359,10 @@ HB_ERRCODE SR_SetBindEmptylValue(COLUMNBINDP BindStructure);
 HB_ERRCODE SR_SetBindValue(PHB_ITEM pFieldData, COLUMNBINDP BindStructure, HSTMT hStmt);
 char *SR_QualifyName(char *szName, SQLEXAREAP thiswa);
 COLUMNBINDP SR_GetBindStruct(SQLEXAREAP thiswa, INDEXBINDP IndexBind);
+COLUMNBINDP SR_GetIndexColBind(SQLEXAREAP thiswa, INDEXBINDP IndexBind);
+PHB_ITEM SR_EvalExprComp(INDEXBINDP IndexBind, PHB_ITEM pRawData);
+void SR_SetExprBindValue(INDEXBINDP IndexBind, PHB_ITEM pXVal);
+void SR_ReleaseIndexBindExpr(INDEXBINDP IndexBindBase);
 HB_BOOL SR_getColumnList(SQLEXAREAP thiswa);
 void SR_SolveFilters(SQLEXAREAP thiswa, HB_BOOL bWhere);
 void SR_getOrderByExpression(SQLEXAREAP thiswa, HB_BOOL bUseOptimizerHints);

--- a/source/sqlex1.c
+++ b/source/sqlex1.c
@@ -801,6 +801,7 @@ void ReleaseIndexBindStructure(SQLEXAREAP thiswa)
         }
         IndexBind++;
       }
+      SR_ReleaseIndexBindExpr(thiswa->IndexBindings[i]);
       hb_xfree(thiswa->IndexBindings[i]);
       thiswa->IndexBindings[i] = SR_NULLPTR;
     }
@@ -814,6 +815,146 @@ COLUMNBINDP SR_GetBindStruct(SQLEXAREAP thiswa, INDEXBINDP IndexBind)
   COLUMNBINDP pBind = thiswa->CurrRecord;
   pBind += (IndexBind->lFieldPosDB - 1); // Place offset
   return pBind;
+}
+
+//----------------------------------------------------------------------------//
+//
+// Expression index support (PostgreSQL)
+//
+// Expression index components carry a SQL expression to be used in place of
+// the column name and a client side codeblock which transforms the raw
+// column value into the key domain (e.g. RTrim(Upper(<value>))). Each
+// component uses a private COLUMNBIND (char domain, component length)
+// instead of the shared per column structure from thiswa->CurrRecord.
+//
+//----------------------------------------------------------------------------//
+
+COLUMNBINDP SR_GetIndexColBind(SQLEXAREAP thiswa, INDEXBINDP IndexBind)
+{
+  if (IndexBind->bIsExpr) {
+    return &(IndexBind->ExprBind);
+  }
+  return SR_GetBindStruct(thiswa, IndexBind);
+}
+
+//----------------------------------------------------------------------------//
+
+PHB_ITEM SR_EvalExprComp(INDEXBINDP IndexBind,
+                         PHB_ITEM pRawData) // Caller must release the returned item
+{
+  HB_EVALINFO info;
+  PHB_ITEM pResult;
+
+  hb_evalNew(&info, hb_itemNew(IndexBind->pExprBlock));
+  hb_evalPutParam(&info, hb_itemNew(pRawData));
+  pResult = hb_evalLaunch(&info);
+  hb_evalRelease(&info);
+
+  if (!pResult) {
+    pResult = hb_itemPutC(SR_NULLPTR, "");
+  }
+
+  return pResult;
+}
+
+//----------------------------------------------------------------------------//
+
+void SR_SetExprBindValue(INDEXBINDP IndexBind, PHB_ITEM pXVal)
+{
+  COLUMNBINDP pBind = &(IndexBind->ExprBind);
+  int size = (int)hb_itemGetCLen(pXVal);
+
+  if (size >= pBind->asChar.size_alloc) {
+    size = pBind->asChar.size_alloc - 1;
+  }
+  if (size > 0) {
+    hb_xmemcpy(pBind->asChar.value, hb_itemGetCPtr(pXVal), size);
+  }
+  pBind->asChar.value[size] = '\0';
+  pBind->asChar.size = size;
+  pBind->lIndPtr = SQL_NTS;
+  pBind->isBoundNULL = HB_FALSE;
+  pBind->isArgumentNull = HB_FALSE;
+}
+
+//----------------------------------------------------------------------------//
+
+static void SR_SetupExprBind(SQLEXAREAP thiswa, INDEXBINDP IndexBind, PHB_ITEM pColDef)
+{
+  COLUMNBINDP RealCol;
+  int iLen;
+
+  IndexBind->bIsExpr = HB_FALSE;
+
+  if (pColDef && HB_IS_ARRAY(pColDef) && hb_arrayLen(pColDef) >= SR_IDXFLD_XFORM &&
+      HB_IS_STRING(hb_arrayGetItemPtr(pColDef, SR_IDXFLD_SQL)) &&
+      hb_arrayGetCLen(pColDef, SR_IDXFLD_SQL) > 0) {
+
+    iLen = (int)hb_arrayGetNL(pColDef, SR_IDXFLD_LEN);
+    if (iLen <= 0) {
+      iLen = 254;
+    }
+
+    if (!thiswa->CurrRecord) {
+      SR_SetCurrRecordStructure(thiswa); // Need the real column info below
+    }
+
+    IndexBind->bIsExpr = HB_TRUE;
+    IndexBind->sExprSQL = hb_strdup(hb_arrayGetCPtr(pColDef, SR_IDXFLD_SQL));
+    IndexBind->pExprBlock = hb_itemNew(hb_arrayGetItemPtr(pColDef, SR_IDXFLD_XFORM));
+
+    RealCol = SR_GetBindStruct(thiswa, IndexBind);
+
+    memset(&(IndexBind->ExprBind), 0, sizeof(COLUMNBIND));
+    IndexBind->ExprBind.iCType = SQL_C_CHAR;
+    IndexBind->ExprBind.iSQLType = SQL_VARCHAR;
+    IndexBind->ExprBind.lFieldPosDB = IndexBind->lFieldPosDB;
+    IndexBind->ExprBind.lFieldPosWA = RealCol->lFieldPosWA;
+    IndexBind->ExprBind.colName = IndexBind->sExprSQL;
+    IndexBind->ExprBind.ColumnSize = (SQLUINTEGER)iLen;
+    IndexBind->ExprBind.DecimalDigits = 0;
+    IndexBind->ExprBind.isNullable = HB_FALSE;
+    IndexBind->ExprBind.isArgumentNull = HB_FALSE;
+    IndexBind->ExprBind.isBoundNULL = HB_FALSE;
+    IndexBind->ExprBind.lIndPtr = SQL_NTS;
+    IndexBind->ExprBind.asChar.value = (SQLCHAR *)hb_xgrab(iLen + 32);
+    IndexBind->ExprBind.asChar.size_alloc = iLen + 32;
+    IndexBind->ExprBind.asChar.value[0] = '\0';
+    IndexBind->ExprBind.asChar.size = 0;
+  }
+}
+
+//----------------------------------------------------------------------------//
+
+void SR_ReleaseIndexBindExpr(INDEXBINDP IndexBindBase)
+{
+  INDEXBINDP IndexBind = IndexBindBase;
+  int n, iCols;
+
+  if (!IndexBindBase) {
+    return;
+  }
+
+  iCols = IndexBind->iIndexColumns;
+
+  for (n = 0; n < iCols; n++) {
+    if (IndexBind->bIsExpr) {
+      if (IndexBind->sExprSQL) {
+        hb_xfree(IndexBind->sExprSQL);
+        IndexBind->sExprSQL = SR_NULLPTR;
+      }
+      if (IndexBind->pExprBlock) {
+        hb_itemRelease(IndexBind->pExprBlock);
+        IndexBind->pExprBlock = SR_NULLPTR;
+      }
+      if (IndexBind->ExprBind.asChar.value) {
+        hb_xfree(IndexBind->ExprBind.asChar.value);
+        IndexBind->ExprBind.asChar.value = SR_NULLPTR;
+      }
+      IndexBind->bIsExpr = HB_FALSE;
+    }
+    IndexBind++;
+  }
 }
 
 //----------------------------------------------------------------------------//
@@ -858,7 +999,7 @@ static void BindAllIndexStmts(SQLEXAREAP thiswa)
       iBind = 1;
 
       for (iLoop = 1; iLoop <= IndexBind->iLevel; iLoop++) {
-        BindStructure = SR_GetBindStruct(thiswa, IndexBindParam);
+        BindStructure = SR_GetIndexColBind(thiswa, IndexBindParam);
         if (!BindStructure->isArgumentNull) {
           switch (BindStructure->iCType) {
           case SQL_C_CHAR: {
@@ -947,7 +1088,7 @@ static void FeedCurrentRecordToBindings(SQLEXAREAP thiswa)
     IndexBind = thiswa->IndexBindings[thiswa->hOrdCurrent];
 
     for (iCol = 1; iCol <= thiswa->indexColumns; iCol++) {
-      BindStructure = SR_GetBindStruct(thiswa, IndexBind);
+      BindStructure = SR_GetIndexColBind(thiswa, IndexBind);
 
       if (BindStructure->lFieldPosWA > 0) {
         // Get item value from Workarea
@@ -959,12 +1100,23 @@ static void FeedCurrentRecordToBindings(SQLEXAREAP thiswa)
       }
 
       if (IndexBind->lFieldPosDB == (HB_LONG)(thiswa->ulhRecno)) {
+        if (!newFieldData) {
+          pFieldData = hb_itemNew(SR_NULLPTR);
+          newFieldData = HB_TRUE;
+        }
         hb_itemPutNL(pFieldData, thiswa->recordList[thiswa->recordListPos]);
       }
 
       if (HB_IS_NIL(pFieldData)) {
         getMissingColumn(thiswa, pFieldData, IndexBind->lFieldPosDB);
       }
+
+      if (IndexBind->bIsExpr) {
+        // Expression index component: bind the transformed value (never NULL)
+        PHB_ITEM pXVal = SR_EvalExprComp(IndexBind, pFieldData);
+        SR_SetExprBindValue(IndexBind, pXVal);
+        hb_itemRelease(pXVal);
+      } else
 
       // Check if column is NULL
 
@@ -1140,6 +1292,7 @@ void SR_SetIndexBindStructure(SQLEXAREAP thiswa)
       IndexBind->hIndexOrder = thiswa->hOrdCurrent;
       IndexBind->iLevel = i;
       IndexBind->iIndexColumns = thiswa->indexColumns;
+      SR_SetupExprBind(thiswa, IndexBind, hb_arrayGetItemPtr(pColumns, i));
       IndexBind++;
     }
   } else {
@@ -1306,7 +1459,9 @@ static HB_ERRCODE getWhereExpression(SQLEXAREAP thiswa, int iListType)
       bWhere = HB_TRUE;
     } else {
       for (iCol = 1; iCol <= thiswa->indexLevel; iCol++) {
-        BindStructure = SR_GetBindStruct(thiswa, IndexBind);
+        PHB_ITEM pXVal = SR_NULLPTR;
+
+        BindStructure = SR_GetIndexColBind(thiswa, IndexBind);
 
         pTemp = SR_NULLPTR;
         pFieldData = SR_NULLPTR;
@@ -1329,6 +1484,12 @@ static HB_ERRCODE getWhereExpression(SQLEXAREAP thiswa, int iListType)
           // Get the synthetic index item value from database
         }
 
+        if (IndexBind->bIsExpr) {
+          // Expression index component: move the raw value to the key domain
+          pXVal = SR_EvalExprComp(IndexBind, pFieldData);
+          pFieldData = pXVal;
+        }
+
         bArgumentIsNull = BindStructure->isNullable && IsItemNull(pFieldData, thiswa);
 
         if (iCol == thiswa->indexLevel) {
@@ -1338,7 +1499,11 @@ static HB_ERRCODE getWhereExpression(SQLEXAREAP thiswa, int iListType)
             // Bind column value only if argument is NOT null
             HSTMT hStmt = thiswa->recordListDirection == SR_LIST_FORWARD ? IndexBind->SkipFwdStmt
                                                                       : IndexBind->SkipBwdStmt;
-            SR_SetBindValue(pFieldData, BindStructure, hStmt);
+            if (IndexBind->bIsExpr) {
+              SR_SetExprBindValue(IndexBind, pFieldData);
+            } else {
+              SR_SetBindValue(pFieldData, BindStructure, hStmt);
+            }
           }
         }
 
@@ -1367,6 +1532,14 @@ static HB_ERRCODE getWhereExpression(SQLEXAREAP thiswa, int iListType)
               hb_xfree(temp);
             }
           }
+        } else if (IndexBind->bIsExpr) {
+          // Expression index component: use the SQL expression as is
+          temp = hb_strdup((const char *)thiswa->sWhere);
+          sprintf(thiswa->sWhere, "%s %s %s %s ?", bWhere ? temp : "\nWHERE",
+                  bWhere ? "AND" : "", IndexBind->sExprSQL,
+                  iCol == thiswa->indexLevel ? (bDirectionFWD ? ">=" : "<=") : "=");
+          bWhere = HB_TRUE;
+          hb_xfree(temp);
         } else {
           temp = hb_strdup((const char *)thiswa->sWhere);
           sprintf(thiswa->sWhere, "%s %s A.%c%s%c %s ?", bWhere ? temp : "\nWHERE",
@@ -1375,6 +1548,9 @@ static HB_ERRCODE getWhereExpression(SQLEXAREAP thiswa, int iListType)
                   iCol == thiswa->indexLevel ? (bDirectionFWD ? ">=" : "<=") : "=");
           bWhere = HB_TRUE;
           hb_xfree(temp);
+        }
+        if (pXVal) {
+          hb_itemRelease(pXVal);
         }
         if (pTemp) {
           hb_itemRelease(pTemp);
@@ -3880,6 +4056,7 @@ static HB_ERRCODE sqlExOrderListFocus(SQLEXAREAP thiswa, LPDBORDERINFO pOrderInf
     s_bOldReverseIndex = thiswa->bReverseIndex;
     thiswa->bReverseIndex = hb_arrayGetL(thiswa->aInfo, SR_AINFO_REVERSE_INDEX);
     if (thiswa->IndexBindings[thiswa->hOrdCurrent]) {
+      SR_ReleaseIndexBindExpr(thiswa->IndexBindings[thiswa->hOrdCurrent]);
       hb_xfree(thiswa->IndexBindings[thiswa->hOrdCurrent]);
       thiswa->IndexBindings[thiswa->hOrdCurrent] = SR_NULLPTR;
     }

--- a/source/sqlex3.c
+++ b/source/sqlex3.c
@@ -131,7 +131,7 @@ static HB_ERRCODE getSeekWhereExpression(SQLEXAREAP thiswa, int iListType, int q
   }
 
   for (iCol = 1; iCol <= queryLevel; iCol++) {
-    BindStructure = SR_GetBindStruct(thiswa, SeekBind);
+    BindStructure = SR_GetIndexColBind(thiswa, SeekBind);
 
     if (BindStructure->isArgumentNull) {
       *bUseOptimizerHints = HB_FALSE; // We cannot use this high speed solution
@@ -159,6 +159,12 @@ static HB_ERRCODE getSeekWhereExpression(SQLEXAREAP thiswa, int iListType, int q
           hb_xfree(temp);
         }
       }
+    } else if (SeekBind->bIsExpr) {
+      // Expression index component: use the SQL expression as is
+      temp = hb_strdup((const char *)thiswa->sWhere);
+      sprintf(thiswa->sWhere, "%s %s %s %s ?", bWhere ? temp : "\nWHERE", bWhere ? "AND" : "",
+              SeekBind->sExprSQL, iCol == queryLevel ? (bDirectionFWD ? ">=" : "<=") : "=");
+      hb_xfree(temp);
     } else {
       temp = hb_strdup((const char *)thiswa->sWhere);
       sprintf(thiswa->sWhere, "%s %s A.%c%s%c %s ?", bWhere ? temp : "\nWHERE",
@@ -372,7 +378,7 @@ HB_ERRCODE SR_FeedSeekKeyToBindings(SQLEXAREAP thiswa, PHB_ITEM pKey, int *query
     SeekBind->hIndexOrder = thiswa->hOrdCurrent; // Store latest prepared index order query
 
     for (iCol = 1; iCol <= thiswa->indexColumns; iCol++) {
-      BindStructure = SR_GetBindStruct(thiswa, SeekBind);
+      BindStructure = SR_GetIndexColBind(thiswa, SeekBind);
 
       if (!thiswa->uiFieldList[(BindStructure->lFieldPosDB) - 1]) {
         thiswa->uiFieldList[(BindStructure->lFieldPosDB) - 1] =
@@ -413,7 +419,7 @@ HB_ERRCODE SR_FeedSeekKeyToBindings(SQLEXAREAP thiswa, PHB_ITEM pKey, int *query
     *queryLevel = thiswa->indexColumns;
 
     for (i = 1; i <= thiswa->indexColumns; i++) {
-      BindStructure = SR_GetBindStruct(thiswa, SeekBind);
+      BindStructure = SR_GetIndexColBind(thiswa, SeekBind);
       size = 0;
 
       switch (BindStructure->iCType) {
@@ -537,7 +543,7 @@ HB_ERRCODE SR_FeedSeekKeyToBindings(SQLEXAREAP thiswa, PHB_ITEM pKey, int *query
     }
   } else {
     *queryLevel = 1;
-    BindStructure = SR_GetBindStruct(thiswa, SeekBind);
+    BindStructure = SR_GetIndexColBind(thiswa, SeekBind);
 
     if (HB_IS_NUMERIC(pKey)) {
       if (BindStructure->iCType != SQL_C_DOUBLE) { // Check column data type
@@ -612,7 +618,7 @@ void SR_BindSeekStmt(SQLEXAREAP thiswa, int queryLevel)
   iBind = 1;
 
   for (iLoop = 1; iLoop <= queryLevel; iLoop++) {
-    BindStructure = SR_GetBindStruct(thiswa, SeekBindParam);
+    BindStructure = SR_GetIndexColBind(thiswa, SeekBindParam);
     if (!BindStructure->isArgumentNull) {
       // Corrigido 27/12/2013 09:53 - lpereira
       // Estava atribuindo o valor de SQLRDD_RDBMS_ORACLE para thiswa->nSystemID.

--- a/source/sqlrdd2.prg
+++ b/source/sqlrdd2.prg
@@ -747,15 +747,15 @@ RETURN cRet
 // always trims character values on PostgreSQL, so equality comparisons stay
 // consistent.
 //
-// The SQLEX RDD builds its queries at C level directly from INDEX_FIELDS and
-// does not understand expression components, so the feature is restricted to
-// the SQLRDD RDD on PostgreSQL connections (see CanUseExpressionIndex()).
+// The SQLEX RDD consumes expression components at C level: the SKIP/SEEK
+// engine (sqlex1/2/3.c) uses the component SQL expression in the generated
+// statements and binds the value transformed by the client side codeblock.
 //
 //-------------------------------------------------------------------------------------------------------------------//
 
 METHOD SR_WORKAREA:CanOpenExpressionIndex()   // opening never depends on SR_GetExpressionIndex()
 
-RETURN ISPOSTGRESQL() .AND. !(RDDNAME() == "SQLEX")
+RETURN ISPOSTGRESQL()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -1951,9 +1951,8 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
 
             IF !::CanOpenExpressionIndex()
                ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
-                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
-                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
-                  " with this RDD or open the table with SQLRDD)")
+                  " (index uses a PostgreSQL expression key;" + ;
+                  " it can only be opened on a PostgreSQL connection)")
                RETURN 0    // error exit
             ENDIF
 
@@ -7346,9 +7345,8 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
 
             IF !::CanOpenExpressionIndex()
                ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
-                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
-                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
-                  " with this RDD or open the table with SQLRDD)")
+                  " (index uses a PostgreSQL expression key;" + ;
+                  " it can only be opened on a PostgreSQL connection)")
                RETURN 0    // error exit
             ENDIF
 

--- a/source/sqlrdd2_postgresql.prg
+++ b/source/sqlrdd2_postgresql.prg
@@ -731,10 +731,11 @@ RETURN cRet
 
 METHOD SR_WORKAREA:CanOpenExpressionIndex()   // opening never depends on SR_GetExpressionIndex()
 
-// The SQLEX RDD builds its queries at C level directly from INDEX_FIELDS
-// and does not understand expression components
+// The SQLEX RDD consumes expression components at C level: the SKIP/SEEK
+// engine (sqlex1/2/3.c) uses the component SQL expression in the generated
+// statements and binds the value transformed by the client side codeblock
 
-RETURN !(RDDNAME() == "SQLEX")
+RETURN .T.
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -1649,9 +1650,8 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
 
             IF !::CanOpenExpressionIndex()
                ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
-                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
-                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
-                  " with this RDD or open the table with SQLRDD)")
+                  " (index uses a PostgreSQL expression key;" + ;
+                  " it can only be opened on a PostgreSQL connection)")
                RETURN 0    // error exit
             ENDIF
 
@@ -5573,9 +5573,8 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
 
             IF !::CanOpenExpressionIndex()
                ::RunTimeErr("18", SR_Msg(18) + aCols[i] + " Table : " + ::cFileName + ;
-                  " (index uses a PostgreSQL expression key created by the SQLRDD RDD;" + ;
-                  " it cannot be opened by the " + RDDNAME() + " RDD - recreate the index" + ;
-                  " with this RDD or open the table with SQLRDD)")
+                  " (index uses a PostgreSQL expression key;" + ;
+                  " it can only be opened on a PostgreSQL connection)")
                RETURN 0    // error exit
             ENDIF
 

--- a/tests/sqlexpgsqlexprindex.prg
+++ b/tests/sqlexpgsqlexprindex.prg
@@ -1,20 +1,16 @@
 // SQLRDD++
-// Indices com funcoes no RDD SQLEX (ODBC/PostgreSQL)
+// Indices de expressao no RDD SQLEX (ODBC/PostgreSQL)
 //
-// O RDD SQLEX monta as consultas em nivel C diretamente a partir das
-// colunas do indice (INDEX_FIELDS) e NAO suporta os indices de expressao
-// nativos do PostgreSQL introduzidos para o RDD SQLRDD.
+// O motor C do SQLEX (sqlex1/2/3.c) agora consome componentes de
+// expressao: o SQL gerado para SKIP/SEEK usa a expressao do componente
+// (rtrim/upper/substr/lpad) e o valor comparado e transformado no lado
+// cliente pelo codeblock do componente.
 //
-// Este exemplo demonstra o comportamento esperado no SQLEX:
-//
-// 1. Indices com funcoes na chave (UPPER, SUBSTR, STRZERO, UDF) criados
-//    sob o SQLEX continuam usando o mecanismo classico da coluna
-//    sintetica INDKEY_ - tudo funciona como sempre funcionou;
-// 2. Indices de EXPRESSAO criados pelo RDD SQLRDD nao podem ser abertos
-//    pelo SQLEX: a abertura gera o erro 18 com mensagem explicativa.
-//    Nesse cenario, recrie o indice sob o SQLEX (vira sintetico) ou abra
-//    a tabela com o SQLRDD. Para cargas em massa via SQLEX sem uso de
-//    indices, RDDINFO(RDDI_AUTOOPEN, .F.) evita a abertura automatica.
+// Este exemplo demonstra que, tambem no SQLEX, indices criados com
+// funcoes padrao do Harbour (UPPER, SUBSTR, LEFT, STRZERO, DTOS, STR)
+// usam indices de expressao nativos do PostgreSQL, SEM criar a coluna
+// extra INDKEY_. Apenas indices com funcao proprietaria (UDF) continuam
+// criando a coluna sintetica.
 //
 // Para compilar (na pasta tests, que linka a lib generica sqlrddpp):
 // hbmk2 sqlexpgsqlexprindex
@@ -69,7 +65,7 @@ PROCEDURE Main()
       CASE HB_PValue(n) == "--database" ; s_ODBC_DATABASE := HB_PValue(++n)
       CASE HB_PValue(n) == "--options"  ; s_ODBC_OPTIONS := HB_PValue(++n)
       OTHERWISE
-         ? "Parâmetro desconhecido:", HB_PValue(n)
+         ? "Parï¿½metro desconhecido:", HB_PValue(n)
       ENDCASE
       ++n
    ENDDO
@@ -125,7 +121,7 @@ PROCEDURE Main()
       CLS
       ? "=============================================================="
       ? " SQLRDD++ - Indices com funcoes no RDD SQLEX (PostgreSQL)"
-      ? " Comportamento classico: chaves com funcao usam INDKEY_"
+      ? " Indices de expressao nativos tambem no SQLEX"
       ? "=============================================================="
       ? ""
       MostraOrdens()
@@ -219,22 +215,22 @@ RETURN
 STATIC PROCEDURE CriaIndices()
 
    ? ""
-   ? "Criando indices sob o SQLEX (chaves com funcao => INDKEY_ classico)..."
+   ? "Criando indices sob o SQLEX (INDEX ON ... TAG <tabela+seq> TO <tabela>)..."
    ? ""
 
-   ? "  TAG testexpx1: UPPER(NOME)                    => sintetico (INDKEY_)"
+   ? "  TAG testexpx1: UPPER(NOME)                    => expressao (sem coluna extra)"
    INDEX ON UPPER(NOME) TAG testexpx1 TO testexpx
 
-   ? "  TAG testexpx2: SUBSTR(CIDADE,1,10)            => sintetico (INDKEY_)"
+   ? "  TAG testexpx2: SUBSTR(CIDADE,1,10)            => expressao (sem coluna extra)"
    INDEX ON SUBSTR(CIDADE, 1, 10) TAG testexpx2 TO testexpx
 
-   ? "  TAG testexpx3: STRZERO(SALDO,12,2)            => sintetico (INDKEY_)"
+   ? "  TAG testexpx3: STRZERO(SALDO,12,2)            => expressao com decimais (sem coluna extra)"
    INDEX ON STRZERO(SALDO, 12, 2) TAG testexpx3 TO testexpx
 
-   ? "  TAG testexpx4: DTOS(ADMISSAO)+STRZERO(ID,10)  => sintetico (INDKEY_)"
+   ? "  TAG testexpx4: DTOS(ADMISSAO)+STRZERO(ID,10)  => data crua + expressao (sem coluna extra)"
    INDEX ON DTOS(ADMISSAO) + STRZERO(ID, 10) TAG testexpx4 TO testexpx
 
-   ? "  TAG testexpx5: MYUDF(NOME)                    => sintetico (INDKEY_)"
+   ? "  TAG testexpx5: MYUDF(NOME)                    => UDF: sintetico (CRIA coluna INDKEY_)"
    INDEX ON MYUDF(NOME) TAG testexpx5 TO testexpx
 
 RETURN
@@ -255,8 +251,7 @@ STATIC PROCEDURE MostraColunasExtras()
    LOCAL aLinha
 
    ? ""
-   ? "Colunas INDKEY_/INDFOR_ existentes na tabela"
-   ? "(no SQLEX o esperado sao colunas INDKEY_ para as chaves com funcao):"
+   ? "Colunas INDKEY_/INDFOR_ existentes na tabela (esperado: apenas 1, do indice via UDF):"
 
    oCnn:Exec("select column_name from information_schema.columns where table_name = '" + ;
              Lower(TABLE_NAME) + "' and (column_name like 'indkey_%' or column_name like 'indfor_%') order by 1", .F., .T., @aRes)
@@ -267,6 +262,12 @@ STATIC PROCEDURE MostraColunasExtras()
       FOR EACH aLinha IN aRes
          ? "  - " + AllTrim(aLinha[1])
       NEXT
+   ENDIF
+
+   IF Len(aRes) == 1
+      ? "  RESULTADO: OK - somente o indice com UDF criou coluna extra"
+   ELSE
+      ? "  RESULTADO: VERIFICAR - quantidade de colunas extras diferente do esperado (" + LTrim(Str(Len(aRes))) + ")"
    ENDIF
 
 RETURN
@@ -280,7 +281,7 @@ STATIC PROCEDURE MostraIndicesFisicos()
    LOCAL aLinha
 
    ? ""
-   ? "Indices fisicos no PostgreSQL (sob o SQLEX apontam para as colunas INDKEY_):"
+   ? "Indices fisicos no PostgreSQL (observe as expressoes rtrim/upper/substr/lpad):"
 
    oCnn:Exec("select indexname, indexdef from pg_indexes where tablename = '" + ;
              Lower(TABLE_NAME) + "' order by 1", .F., .T., @aRes)


### PR DESCRIPTION
Until now the SQLEX RDD was excluded from the PostgreSQL expression
index feature: keys with Harbour functions kept creating the synthetic
INDKEY_ column even with SR_SetExpressionIndex(.T.) (reported by Mario
Sabado). SQLEX builds its SKIP/SEEK statements at C level with
per-column bindings, so it could not consume expression components.

The C engine now understands expression components:

- INDEXBIND (sqlex.h) carries the component SQL expression, the client
  side transform codeblock and a private COLUMNBIND (char domain, with
  the component length). COLUMNBIND was moved before INDEXBIND so it
  can be embedded.
- New helpers in sqlex1.c: SR_GetIndexColBind(), SR_EvalExprComp(),
  SR_SetExprBindValue(), SR_SetupExprBind() (component setup inside
  SR_SetIndexBindStructure) and SR_ReleaseIndexBindExpr() (cleanup in
  ReleaseIndexBindStructure and sqlExOrderListFocus).
- SKIP (getWhereExpression / BindAllIndexStmts /
  FeedCurrentRecordToBindings) and SEEK (getSeekWhereExpression /
  SR_FeedSeekKeyToBindings / SR_BindSeekStmt) emit the component SQL
  expression in place of the column name and bind the transformed
  value. ORDER BY already came from the PRG-built
  ORDER_ASCEND/ORDER_DESEND strings, which carry the expressions.
- PRG guards updated: CanOpenExpressionIndex()/CanUseExpressionIndex()
  no longer exclude the SQLEX RDD, so INDEX ON UPPER(...) & co. under
  SQLEX now create native expression indexes; only untranslatable (UDF)
  keys keep the synthetic INDKEY_ column.

Compatibility: synthetic and plain-column indexes keep working
unchanged - components without the SQL expression slot bypass the new
code entirely.

tests/sqlexpgsqlexprindex.prg updated to the new expected behavior
(only the UDF index creates an INDKEY_ column under SQLEX): index
creation, information_schema/pg_indexes verification, SEEK batteries
(exact/not-found/partial) and DBEDIT browsing per order. Field-tested
against PostgreSQL via ODBC; both sqlrddpp and sqlrddpp-postgresql
build clean (the native build also ships the SQLEX engine).

Closes the gap reported in the SR_SetSyntheticIndex(.F.) +
SR_SetExpressionIndex(.T.) scenario on SQLEX.
