### PR TITLE
Fix: trim IDXCOL_ from SR_MGMNTINDEXES (Index Column not Found - INDKEY_nnn)

### DIFF
--- a/source/sqlrdd2.prg
+++ b/source/sqlrdd2.prg
@@ -1967,7 +1967,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
    FOR nInd := 1 TO Len(::aIndexMgmnt)
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
          // aCols := HB_ATokens(StrTran(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], Chr(34), ""), ",")
@@ -2115,7 +2115,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
             // side (same value stored in INDKEY_, without the recno suffix)
             ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY]) + ") }")
          ELSE
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")
@@ -3060,9 +3060,9 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                      cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                      IF ISPOSTGRESQL()
-                        cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS], ::oSql:nSystemID) + " = E'" + cKey + "' "
+                        cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]), ::oSql:nSystemID) + " = E'" + cKey + "' "
                      ELSE
-                        cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS], ::oSql:nSystemID) + " = '" + cKey + "' "
+                        cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]), ::oSql:nSystemID) + " = '" + cKey + "' "
                      ENDIF
                      ::aLocalBuffer[::aIndexMgmnt[nInd, SR_INDEXMAN_SYNTH_COLPOS]] := cKey
                   ENDIF
@@ -3261,7 +3261,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
          FOR nInd := 1 TO Len(::aIndexMgmnt)
             IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                IF ::cIns == NIL
-                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS], ::oSql:nSystemID)
+                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]), ::oSql:nSystemID)
                ENDIF
                cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                IF ISPOSTGRESQL()
@@ -7305,7 +7305,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
    FOR EACH nInd IN aInd
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          IF HB_IsChar(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY])
             aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
@@ -7479,7 +7479,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
             // side (same value stored in INDKEY_, without the recno suffix)
             ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY]) + ") }")
          ELSE
-            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")

--- a/source/sqlrdd2.prg
+++ b/source/sqlrdd2.prg
@@ -1143,6 +1143,11 @@ METHOD SR_WORKAREA:LoadRegisteredTags()
          ENDIF
          aInd[SR_INDEXMAN_IDXKEY] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 5)
       ENDIF
+      // IDXCOL_ is CHAR(3), but a driver may return character values space
+      // padded to the width it reports for the column. Trim it here: the
+      // INDKEY_nnn name is built by concatenation and the padding would make
+      // it stop matching the column names in ::aNames
+      aInd[SR_INDEXMAN_COLUMNS] := AllTrim(aInd[SR_INDEXMAN_COLUMNS])
       IF !Empty(aInd[SR_INDEXMAN_COLUMNS])
          aInd[SR_INDEXMAN_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(aInd[SR_INDEXMAN_IDXKEY]) + ") + Str(RecNo(),15) }")
          aInd[SR_INDEXMAN_SYNTH_COLPOS] := AScan(::aNames, "INDKEY_" + aInd[SR_INDEXMAN_COLUMNS])     // Make life easier in odbcrdd2.c

--- a/source/sqlrdd2_firebird.prg
+++ b/source/sqlrdd2_firebird.prg
@@ -692,6 +692,11 @@ METHOD SR_WORKAREA:LoadRegisteredTags()
       IF SubStr(aInd[SR_INDEXMAN_IDXKEY], 4, 1) == "@"
          aInd[SR_INDEXMAN_IDXKEY] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 5)
       ENDIF
+      // IDXCOL_ is CHAR(3), but a driver may return character values space
+      // padded to the width it reports for the column. Trim it here: the
+      // INDKEY_nnn name is built by concatenation and the padding would make
+      // it stop matching the column names in ::aNames
+      aInd[SR_INDEXMAN_COLUMNS] := AllTrim(aInd[SR_INDEXMAN_COLUMNS])
       IF !Empty(aInd[SR_INDEXMAN_COLUMNS])
          aInd[SR_INDEXMAN_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(aInd[SR_INDEXMAN_IDXKEY]) + ") + Str(RecNo(),15) }")
          aInd[SR_INDEXMAN_SYNTH_COLPOS] := AScan(::aNames, "INDKEY_" + aInd[SR_INDEXMAN_COLUMNS])     // Make life easier in odbcrdd2.c

--- a/source/sqlrdd2_firebird.prg
+++ b/source/sqlrdd2_firebird.prg
@@ -1171,7 +1171,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
    FOR nInd := 1 TO Len(::aIndexMgmnt)
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
          // aCols := HB_ATokens(StrTran(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], Chr(34), ""), ",")
@@ -1252,9 +1252,9 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
       ::aIndex[nInd, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")
@@ -2067,7 +2067,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
                FOR nInd := 1 TO Len(::aIndexMgmnt)
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                      cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
-                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]) + " = '" + cKey + "' "
+                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])) + " = '" + cKey + "' "
                      ::aLocalBuffer[::aIndexMgmnt[nInd, SR_INDEXMAN_SYNTH_COLPOS]] := cKey
                   ENDIF
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_FOR_CODEBLOCK])
@@ -2231,7 +2231,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
          FOR nInd := 1 TO Len(::aIndexMgmnt)
             IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                IF ::cIns == NIL
-                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
                ENDIF
                cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                cVal += IIf(!lFirst, ", '", "( '") + cKey + "'"
@@ -4981,7 +4981,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
    FOR EACH nInd IN aInd
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          IF HB_IsChar(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY])
             aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
@@ -5073,9 +5073,9 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
       ::aIndex[nLen, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")

--- a/source/sqlrdd2_mysql.prg
+++ b/source/sqlrdd2_mysql.prg
@@ -1064,6 +1064,13 @@ METHOD SR_WORKAREA:LoadRegisteredTags()
       IF SubStr(aInd[SR_INDEXMAN_IDXKEY], 4, 1) == "@"
          aInd[SR_INDEXMAN_IDXKEY] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 5)
       ENDIF
+      // IDXCOL_ is CHAR(3), but some drivers return character values space
+      // padded to the width they report for the column - the native MySQL one
+      // reports field->length (in bytes) whenever the column charset differs
+      // from the connection charset, so a CHAR(3) in utf8mb4 comes back as 12.
+      // Trim it here: the INDKEY_nnn name is built by concatenation and the
+      // padding would make it stop matching the column names in ::aNames
+      aInd[SR_INDEXMAN_COLUMNS] := AllTrim(aInd[SR_INDEXMAN_COLUMNS])
       IF !Empty(aInd[SR_INDEXMAN_COLUMNS])
          aInd[SR_INDEXMAN_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(aInd[SR_INDEXMAN_IDXKEY]) + ") + Str(RecNo(),15) }")
          aInd[SR_INDEXMAN_SYNTH_COLPOS] := AScan(::aNames, "INDKEY_" + aInd[SR_INDEXMAN_COLUMNS])     // Make life easier in odbcrdd2.c

--- a/source/sqlrdd2_mysql.prg
+++ b/source/sqlrdd2_mysql.prg
@@ -1590,7 +1590,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
    FOR nInd := 1 TO Len(::aIndexMgmnt)
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
          // aCols := HB_ATokens(StrTran(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], Chr(34), ""), ",")
@@ -1699,9 +1699,9 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
       ::aIndex[nInd, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")
@@ -2531,7 +2531,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
                FOR nInd := 1 TO Len(::aIndexMgmnt)
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                      cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
-                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]) + " = '" + cKey + "' "
+                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])) + " = '" + cKey + "' "
                      ::aLocalBuffer[::aIndexMgmnt[nInd, SR_INDEXMAN_SYNTH_COLPOS]] := cKey
                   ENDIF
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_FOR_CODEBLOCK])
@@ -2678,7 +2678,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
          FOR nInd := 1 TO Len(::aIndexMgmnt)
             IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                IF ::cIns == NIL
-                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
                ENDIF
                cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                cVal += IIf(!lFirst, ", '", "( '") + cKey + "'"
@@ -5463,7 +5463,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
    FOR EACH nInd IN aInd
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          IF HB_IsChar(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY])
             aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
@@ -5576,9 +5576,9 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
       ::aIndex[nLen, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")

--- a/source/sqlrdd2_oracle.prg
+++ b/source/sqlrdd2_oracle.prg
@@ -696,6 +696,11 @@ METHOD SR_WORKAREA:LoadRegisteredTags()
          aInd[SR_INDEXMAN_VIRTUAL_SYNTH] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 1, 3) + SubStr(::cFileName, 1, 25)
          aInd[SR_INDEXMAN_IDXKEY] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 5)
       ENDIF
+      // IDXCOL_ is CHAR(3), but a driver may return character values space
+      // padded to the width it reports for the column. Trim it here: the
+      // INDKEY_nnn name is built by concatenation and the padding would make
+      // it stop matching the column names in ::aNames
+      aInd[SR_INDEXMAN_COLUMNS] := AllTrim(aInd[SR_INDEXMAN_COLUMNS])
       IF !Empty(aInd[SR_INDEXMAN_COLUMNS])
          aInd[SR_INDEXMAN_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(aInd[SR_INDEXMAN_IDXKEY]) + ") + Str(RecNo(),15) }")
          aInd[SR_INDEXMAN_SYNTH_COLPOS] := AScan(::aNames, "INDKEY_" + aInd[SR_INDEXMAN_COLUMNS])     // Make life easier in odbcrdd2.c

--- a/source/sqlrdd2_oracle.prg
+++ b/source/sqlrdd2_oracle.prg
@@ -1266,7 +1266,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
    FOR nInd := 1 TO Len(::aIndexMgmnt)
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
          // aCols := HB_ATokens(StrTran(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], Chr(34), ""), ",")
@@ -1347,9 +1347,9 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
       ::aIndex[nInd, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")
@@ -2158,7 +2158,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
                FOR nInd := 1 TO Len(::aIndexMgmnt)
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                      cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
-                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]) + " = '" + cKey + "' "
+                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])) + " = '" + cKey + "' "
                      ::aLocalBuffer[::aIndexMgmnt[nInd, SR_INDEXMAN_SYNTH_COLPOS]] := cKey
                   ENDIF
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_FOR_CODEBLOCK])
@@ -2310,7 +2310,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
          FOR nInd := 1 TO Len(::aIndexMgmnt)
             IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                IF ::cIns == NIL
-                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
                ENDIF
                cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                cVal += IIf(!lFirst, ", '", "( '") + cKey + "'"
@@ -5230,7 +5230,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
    FOR EACH nInd IN aInd
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          IF HB_IsChar(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY])
             aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
@@ -5315,9 +5315,9 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
       ::aIndex[nLen, SR_AINDEX_INDEX_KEY] := RTrim(IIf(nInd > 0 .AND. (!Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])), ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], cXBase))
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
          IF RDDNAME() == "SQLEX"
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")  //AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ELSE
-            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")

--- a/source/sqlrdd2_postgresql.prg
+++ b/source/sqlrdd2_postgresql.prg
@@ -1061,6 +1061,11 @@ METHOD SR_WORKAREA:LoadRegisteredTags()
       IF SubStr(aInd[SR_INDEXMAN_IDXKEY], 4, 1) == "@"
          aInd[SR_INDEXMAN_IDXKEY] := SubStr(aInd[SR_INDEXMAN_IDXKEY], 5)
       ENDIF
+      // IDXCOL_ is CHAR(3), but a driver may return character values space
+      // padded to the width it reports for the column. Trim it here: the
+      // INDKEY_nnn name is built by concatenation and the padding would make
+      // it stop matching the column names in ::aNames
+      aInd[SR_INDEXMAN_COLUMNS] := AllTrim(aInd[SR_INDEXMAN_COLUMNS])
       IF !Empty(aInd[SR_INDEXMAN_COLUMNS])
          aInd[SR_INDEXMAN_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(aInd[SR_INDEXMAN_IDXKEY]) + ") + Str(RecNo(),15) }")
          aInd[SR_INDEXMAN_SYNTH_COLPOS] := AScan(::aNames, "INDKEY_" + aInd[SR_INDEXMAN_COLUMNS])     // Make life easier in odbcrdd2.c

--- a/source/sqlrdd2_postgresql.prg
+++ b/source/sqlrdd2_postgresql.prg
@@ -1606,7 +1606,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
    FOR nInd := 1 TO Len(::aIndexMgmnt)
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
          // aCols := HB_ATokens(StrTran(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY], Chr(34), ""), ",")
@@ -1730,7 +1730,7 @@ METHOD SR_WORKAREA:sqlOpenAllIndexes()
             // side (same value stored in INDKEY_, without the recno suffix)
             ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY]) + ") }")
          ELSE
-            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nInd, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")
@@ -2573,7 +2573,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
                FOR nInd := 1 TO Len(::aIndexMgmnt)
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                      cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
-                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]) + " = E'" + cKey + "' "
+                     cRet += ", " + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])) + " = E'" + cKey + "' "
                      ::aLocalBuffer[::aIndexMgmnt[nInd, SR_INDEXMAN_SYNTH_COLPOS]] := cKey
                   ENDIF
                   IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_FOR_CODEBLOCK])
@@ -2721,7 +2721,7 @@ METHOD SR_WORKAREA:WriteBuffer(lInsert, aBuffer)
          FOR nInd := 1 TO Len(::aIndexMgmnt)
             IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
                IF ::cIns == NIL
-                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+                  cRet += IIf(!lFirst, ", ", "( ") + SR_DBQUALIFY("INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
                ENDIF
                cKey := (::cAlias)->(SR_ESCAPESTRING(Eval(::aIndexMgmnt[nInd, SR_INDEXMAN_KEY_CODEBLOCK]), ::oSql:nSystemID))
                cVal += IIf(!lFirst, ", E'", "( E'") + cKey + "'"
@@ -5497,7 +5497,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
    FOR EACH nInd IN aInd
 
       IF !Empty(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
-         aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}
+         aCols := {"INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])}
       ELSE
          IF HB_IsChar(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY])
             aCols := &("{" + ::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY] + "}")
@@ -5625,7 +5625,7 @@ METHOD SR_WORKAREA:sqlOrderListAdd(cBagName, cTag)
             // side (same value stored in INDKEY_, without the recno suffix)
             ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| SR_Val2Char(" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_IDXKEY]) + ") }")
          ELSE
-            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])
+            ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := AScan(::aNames, "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]))
          ENDIF
       ELSE
          ::aIndex[nLen, SR_AINDEX_INDEX_KEY_CODEBLOCK] := &("{|| " + cXBase + " }")

--- a/tests/mysql/testindkeypad.prg
+++ b/tests/mysql/testindkeypad.prg
@@ -1,0 +1,416 @@
+// SQLRDD++
+// Reproduz o erro "Index Column not Found - INDKEY_001  Table : <tabela>"
+// no MySQL com conexao nativa (reportado por Mario Sabado, MySQL 9.7.1)
+//
+// CAUSA
+// -----
+// IDXCOL_ em SR_MGMNTINDEXES e CHAR(3). O driver nativo do MySQL devolve
+// todo valor CHAR preenchido com espacos ate a largura que ele calculou
+// para a coluna (MSQLFieldGet(), caso SQL_CHAR), e SR_MYSQueryAttr()
+// calcula essa largura dividindo field->length pelo numero de bytes por
+// caractere do charset - mas so quando o charset da COLUNA bate com o da
+// CONEXAO. A comparacao e feita entre ids de COLLATION
+// (field->charsetnr == cs.number), entao utf8mb4_0900_ai_ci (255) numa
+// conexao utf8mb4_general_ci (45) nao bate, a divisao nao e aplicada e
+// field->length (em BYTES) e usado direto: CHAR(3) em utf8mb4 vira 12.
+//
+// Com isso IDXCOL_ volta como "001" seguido de 9 espacos, e o nome da
+// coluna montado por concatenacao vira "INDKEY_001         ", que nao
+// casa mais com os nomes em ::aNames - a busca usa ==, que em Harbour
+// exige mesmo comprimento.
+//
+// O erro aparece no SET INDEX TO (sqlOrderListAdd) e existe tanto se a
+// coluna INDKEY_001 existir quanto se nao existir - o problema e o nome
+// procurado, nao a coluna.
+//
+// Para compilar:
+// hbmk2 testindkeypad
+//
+// Para executar:
+// testindkeypad --server <servidor> --port <porta> --uid <usuario> --pwd <senha> --dtb <banco>
+//
+// Opcao --keep: nao apaga a tabela de teste no final (para inspecao manual)
+
+#ifdef __XHARBOUR__
+#xtranslate HB_PVALUE([<x,...>]) => PVALUE(<x>)
+#endif
+
+#include "sqlrdd.ch"
+#include "inkey.ch"
+
+#define RDD_NAME "SQLRDD"
+#define TABLE_NAME "arbankt"
+#define BAG_NAME "ARBANKT"
+#define TAG_1 "ARBANKT1"
+#define TAG_2 "ARBANKT2"
+
+REQUEST SQLRDD
+REQUEST SR_MYSQL
+
+REQUEST UPPER
+
+STATIC s_SERVER := "localhost"
+STATIC s_PORT   := "3306"
+STATIC s_UID    := "root"
+STATIC s_PWD    := "password"
+STATIC s_DTB    := "dbtest"
+
+STATIC s_nPad := 0      // largura com que IDXCOL_ voltou do driver
+
+PROCEDURE Main()
+
+   LOCAL nConnection
+   LOCAL n
+   LOCAL lKeep := .F.
+   LOCAL stringConect
+   LOCAL lFalhou
+
+   n := 1
+   DO WHILE n <= PCount()
+      DO CASE
+      CASE HB_PValue(n) == "--server" ; s_SERVER := HB_PValue(++n)
+      CASE HB_PValue(n) == "--port"   ; s_PORT := HB_PValue(++n)
+      CASE HB_PValue(n) == "--uid"    ; s_UID := HB_PValue(++n)
+      CASE HB_PValue(n) == "--pwd"    ; s_PWD := HB_PValue(++n)
+      CASE HB_PValue(n) == "--dtb"    ; s_DTB := HB_PValue(++n)
+      CASE HB_PValue(n) == "--keep"   ; lKeep := .T.
+      OTHERWISE
+         ? "Parametro desconhecido:", HB_PValue(n)
+      ENDCASE
+      ++n
+   ENDDO
+
+   SET DATE ANSI
+   SET CENTURY ON
+
+   rddSetDefault(RDD_NAME)
+
+   stringConect := "MySQL=" + s_SERVER + ";PORT=" + s_PORT + ";UID=" + s_UID + ";PWD=" + s_PWD + ";DTB=" + s_DTB
+
+   ? "Conectando em " + s_SERVER + ":" + s_PORT + "/" + s_DTB + " ..."
+
+   nConnection := sr_AddConnection(CONNECT_MYSQL, stringConect)
+
+   IF nConnection < 0
+      ? "Erro de conexao. Veja sqlerror.log para detalhes."
+      WAIT
+      QUIT
+   ENDIF
+
+   sr_StartLog(nConnection)
+
+   MostraAmbiente()
+   CriaTabela()
+   CriaIndices()
+   MedePadding()
+
+   lFalhou := AbreComoNoRelato()
+
+   Veredito(lFalhou)
+
+   IF !lKeep
+      CLOSE DATABASE
+      sr_DropTable(TABLE_NAME)
+   ENDIF
+
+   CLOSE DATABASE
+   sr_StopLog(nConnection)
+   sr_EndConnection(nConnection)
+
+   ? ""
+   WAIT "Pressione uma tecla..."
+
+RETURN
+
+//--------------------------------------------------------------------
+// Versao do servidor, charset da conexao e collation do IDXCOL_
+
+STATIC PROCEDURE MostraAmbiente()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL aRes := {}
+   LOCAL aRow
+
+   ? ""
+   ? "=============================================================="
+   ? " Ambiente"
+   ? "=============================================================="
+
+   ? "Versao reportada pelo driver : " + AllTrim(SR_Val2Char(oCnn:cSystemVers))
+
+   aRes := {}
+   oCnn:Exec("select version()", .F., .T., @aRes)
+   IF Len(aRes) > 0
+      ? "select version()             : " + AllTrim(SR_Val2Char(aRes[1, 1]))
+   ENDIF
+
+   aRes := {}
+   oCnn:Exec("show variables like 'character_set_client'", .F., .T., @aRes)
+   FOR EACH aRow IN aRes
+      ? "character_set_client         : " + AllTrim(SR_Val2Char(aRow[2]))
+   NEXT
+
+   aRes := {}
+   oCnn:Exec("show variables like 'collation_connection'", .F., .T., @aRes)
+   FOR EACH aRow IN aRes
+      ? "collation_connection         : " + AllTrim(SR_Val2Char(aRow[2]))
+   NEXT
+
+   // Collation real da coluna IDXCOL_ no catalogo
+
+   aRes := {}
+   oCnn:Exec("select CHARACTER_SET_NAME, COLLATION_NAME, CHARACTER_MAXIMUM_LENGTH " + ;
+             "from information_schema.columns " + ;
+             "where TABLE_SCHEMA = database() and TABLE_NAME = 'SR_MGMNTINDEXES' " + ;
+             "and COLUMN_NAME = 'IDXCOL_'", .F., .T., @aRes)
+
+   IF Len(aRes) > 0
+      ? "IDXCOL_ charset / collation  : " + AllTrim(SR_Val2Char(aRes[1, 1])) + " / " + ;
+                                            AllTrim(SR_Val2Char(aRes[1, 2]))
+      ? "IDXCOL_ largura declarada    : " + AllTrim(SR_Val2Char(aRes[1, 3])) + " caracteres"
+   ELSE
+      ? "IDXCOL_                      : SR_MGMNTINDEXES ainda nao existe"
+   ENDIF
+
+RETURN
+
+//--------------------------------------------------------------------
+// Tabela pequena no formato da ARBANK do relato
+
+STATIC PROCEDURE CriaTabela()
+
+   LOCAL aBancos := {"BDO-0001|BANCO DE ORO", ;
+                     "BF000001|BANCO FILIPINO", ;
+                     "BPI00001|BANK OF THE PHIL ISLANDS", ;
+                     "MB000001|METROBANK", ;
+                     "UB000001|UNIONBANK"}
+   LOCAL cItem
+   LOCAL nPos
+
+   ? ""
+   ? "=============================================================="
+   ? " Criando a tabela de teste"
+   ? "=============================================================="
+
+   IF sr_ExistTable(TABLE_NAME)
+      ? "Removendo tabela anterior..."
+      sr_DropTable(TABLE_NAME)
+   ENDIF
+
+   dbCreate(TABLE_NAME, {{"BANK_CODE", "C", 10, 0}, ;
+                         {"BANK_NAME", "C", 40, 0}, ;
+                         {"ADDRESS",   "C", 40, 0}, ;
+                         {"BALANCE",   "N", 14, 2}}, RDD_NAME)
+
+   USE (TABLE_NAME) EXCLUSIVE NEW VIA (RDD_NAME)
+
+   FOR EACH cItem IN aBancos
+      nPos := At("|", cItem)
+      dbAppend()
+      FIELD->BANK_CODE := Left(cItem, nPos - 1)
+      FIELD->BANK_NAME := SubStr(cItem, nPos + 1)
+      FIELD->ADDRESS   := "MANILA"
+      FIELD->BALANCE   := 1000
+   NEXT
+
+   dbCommit()
+
+   ? "Tabela " + TABLE_NAME + " criada com " + AllTrim(Str(LastRec())) + " registros"
+
+   CLOSE DATABASE
+
+RETURN
+
+//--------------------------------------------------------------------
+// Indices no formato do relato: bag unico, dois tags, caminho sintetico
+// classico (SR_SetSyntheticIndex(.T.) + SR_SetExpressionIndex(.F.))
+
+STATIC PROCEDURE CriaIndices()
+
+   ? ""
+   ? "=============================================================="
+   ? " Criando os indices (caminho sintetico classico)"
+   ? "=============================================================="
+
+   SR_SetSyntheticIndex(.T.)
+   SR_SetExpressionIndex(.F.)
+
+   USE (TABLE_NAME) EXCLUSIVE NEW VIA (RDD_NAME)
+
+   ? "INDEX ON BANK_CODE        TAG " + TAG_1 + " TO " + BAG_NAME
+   INDEX ON BANK_CODE TAG (TAG_1) TO (BAG_NAME)
+
+   ? "INDEX ON UPPER(BANK_NAME) TAG " + TAG_2 + " TO " + BAG_NAME
+   INDEX ON UPPER(BANK_NAME) TAG (TAG_2) TO (BAG_NAME)
+
+   CLOSE DATABASE
+
+   MostraCatalogo()
+
+RETURN
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE MostraCatalogo()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL aRes := {}
+   LOCAL aRow
+
+   ? ""
+   ? "Registros em SR_MGMNTINDEXES:"
+
+   oCnn:Exec("select IDXNAME_, TAG_, IDXCOL_, IDXKEY_ from SR_MGMNTINDEXES " + ;
+             "where TABLE_ = '" + Upper(TABLE_NAME) + "' order by TAGNUM_", .F., .T., @aRes)
+
+   FOR EACH aRow IN aRes
+      ? "  bag=" + AllTrim(SR_Val2Char(aRow[1])) + ;
+        "  tag=" + AllTrim(SR_Val2Char(aRow[2])) + ;
+        "  idxcol=[" + SR_Val2Char(aRow[3]) + "]" + ;
+        "  key=" + AllTrim(SR_Val2Char(aRow[4]))
+   NEXT
+
+   ? ""
+   ? "Colunas INDKEY_ existentes na tabela:"
+
+   aRes := {}
+   oCnn:Exec("select COLUMN_NAME from information_schema.columns " + ;
+             "where TABLE_SCHEMA = database() and TABLE_NAME = '" + Lower(TABLE_NAME) + "' " + ;
+             "and COLUMN_NAME like 'INDKEY%' order by COLUMN_NAME", .F., .T., @aRes)
+
+   IF Len(aRes) == 0
+      ? "  (nenhuma)"
+   ELSE
+      FOR EACH aRow IN aRes
+         ? "  " + AllTrim(SR_Val2Char(aRow[1]))
+      NEXT
+   ENDIF
+
+RETURN
+
+//--------------------------------------------------------------------
+// O ponto central: le IDXCOL_ pelo driver e mede o comprimento.
+// 3 = correto. Qualquer valor maior = padding, e o erro vai acontecer.
+
+STATIC PROCEDURE MedePadding()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL aRes := {}
+   LOCAL aRow
+   LOCAL cVal
+
+   ? ""
+   ? "=============================================================="
+   ? " Comprimento do IDXCOL_ como o driver o entrega"
+   ? "=============================================================="
+
+   oCnn:Exec("select IDXCOL_ from SR_MGMNTINDEXES where TABLE_ = '" + ;
+             Upper(TABLE_NAME) + "' order by TAGNUM_", .F., .T., @aRes)
+
+   FOR EACH aRow IN aRes
+      cVal := SR_Val2Char(aRow[1])
+      s_nPad := Max(s_nPad, Len(cVal))
+      ? "  [" + cVal + "] len = " + AllTrim(Str(Len(cVal))) + ;
+        "   nome montado: [INDKEY_" + cVal + "]"
+   NEXT
+
+   ? ""
+
+   IF s_nPad > 3
+      ? "  >> PADDING PRESENTE. IDXCOL_ deveria ter 3 caracteres e veio com " + ;
+        AllTrim(Str(s_nPad)) + "."
+      ? "  >> O nome procurado carrega " + AllTrim(Str(s_nPad - 3)) + ;
+        " espacos a mais e nao vai casar com o nome real da coluna."
+   ELSEIF s_nPad == 0
+      ? "  >> Nenhum registro sintetico encontrado no catalogo."
+   ELSE
+      ? "  >> Sem padding (len = 3). Este ambiente NAO reproduz o erro."
+   ENDIF
+
+RETURN
+
+//--------------------------------------------------------------------
+// Reproduz exatamente a sequencia de abertura do relato
+
+STATIC FUNCTION AbreComoNoRelato()
+
+   LOCAL bOld := ErrorBlock({|e|Break(e)})
+   LOCAL oErr
+   LOCAL lFalhou := .F.
+   LOCAL cOnde := ""
+
+   ? ""
+   ? "=============================================================="
+   ? " Abrindo a tabela como no relato"
+   ? "=============================================================="
+
+   BEGIN SEQUENCE
+
+      cOnde := "USE " + TABLE_NAME + " VIA " + RDD_NAME + " SHARED NEW"
+      ? cOnde
+      USE (TABLE_NAME) VIA (RDD_NAME) SHARED NEW
+
+      cOnde := "SET INDEX TO " + BAG_NAME + " ADDITIVE"
+      ? cOnde
+      SET INDEX TO (BAG_NAME) ADDITIVE
+
+      cOnde := "SET ORDER TO TAG " + TAG_1
+      ? cOnde
+      SET ORDER TO TAG (TAG_1)
+
+      cOnde := ""
+
+   RECOVER USING oErr
+
+      lFalhou := .T.
+
+   END SEQUENCE
+
+   ErrorBlock(bOld)
+
+   IF lFalhou
+      ? ""
+      ? "  FALHOU em: " + cOnde
+      ? "  Erro     : " + AllTrim(SR_Val2Char(oErr:description))
+   ELSE
+      ? ""
+      ? "  Abertura concluida sem erro."
+      ? "  Ordem ativa: " + AllTrim(SR_Val2Char(ordName())) + ;
+        "   registros: " + AllTrim(Str(LastRec()))
+      dbGoTop()
+      ? "  Primeiro registro na ordem: " + AllTrim(SR_Val2Char(FIELD->BANK_CODE)) + ;
+        " - " + AllTrim(SR_Val2Char(FIELD->BANK_NAME))
+   ENDIF
+
+RETURN lFalhou
+
+//--------------------------------------------------------------------
+
+STATIC PROCEDURE Veredito(lFalhou)
+
+   ? ""
+   ? "=============================================================="
+   ? " Resultado"
+   ? "=============================================================="
+
+   DO CASE
+
+   CASE lFalhou .AND. s_nPad > 3
+      ? "REPRODUZIDO. O IDXCOL_ veio com " + AllTrim(Str(s_nPad)) + " caracteres em vez de 3,"
+      ? "e a abertura falhou - e o mesmo caso do relato."
+
+   CASE lFalhou .AND. s_nPad <= 3
+      ? "FALHOU, MAS SEM PADDING. O IDXCOL_ veio com o tamanho correto,"
+      ? "entao a causa aqui e outra. Vale olhar o sqlerror.log."
+
+   CASE !lFalhou .AND. s_nPad > 3
+      ? "CORRIGIDO. O driver ainda entrega IDXCOL_ com " + AllTrim(Str(s_nPad)) + " caracteres,"
+      ? "mas a biblioteca normaliza o valor e a abertura funciona."
+
+   OTHERWISE
+      ? "OK, porem sem padding neste ambiente - o teste nao exercitou o problema."
+      ? "Veja no README como forcar a diferenca de charset no catalogo."
+
+   ENDCASE
+
+RETURN

--- a/tests/mysql/testindkeypad.prg
+++ b/tests/mysql/testindkeypad.prg
@@ -30,6 +30,18 @@
 // testindkeypad --server <servidor> --port <porta> --uid <usuario> --pwd <senha> --dtb <banco>
 //
 // Opcao --keep: nao apaga a tabela de teste no final (para inspecao manual)
+//
+// Opcao --forcecs <collation>: converte SR_MGMNTINDEXES para a collation
+// informada antes de criar os indices. O erro so aparece quando a
+// collation da COLUNA difere da collation da CONEXAO, entao para
+// reproduzir basta escolher uma collation utf8mb4 diferente da que a
+// conexao negociou (o teste mostra as duas no bloco Ambiente):
+//
+//   testindkeypad ... --forcecs utf8mb4_general_ci
+//
+// Com a conexao em utf8mb4_0900_ai_ci isso da a mesma largura de 12 que
+// o Mario reportou. Use --forcecs utf8mb4_0900_ai_ci para voltar ao caso
+// que funciona e comparar.
 
 #ifdef __XHARBOUR__
 #xtranslate HB_PVALUE([<x,...>]) => PVALUE(<x>)
@@ -56,6 +68,7 @@ STATIC s_PWD    := "password"
 STATIC s_DTB    := "dbtest"
 
 STATIC s_nPad := 0      // largura com que IDXCOL_ voltou do driver
+STATIC s_COLLATION := ""   // --forcecs
 
 PROCEDURE Main()
 
@@ -74,6 +87,7 @@ PROCEDURE Main()
       CASE HB_PValue(n) == "--pwd"    ; s_PWD := HB_PValue(++n)
       CASE HB_PValue(n) == "--dtb"    ; s_DTB := HB_PValue(++n)
       CASE HB_PValue(n) == "--keep"   ; lKeep := .T.
+      CASE HB_PValue(n) == "--forcecs"; s_COLLATION := HB_PValue(++n)
       OTHERWISE
          ? "Parametro desconhecido:", HB_PValue(n)
       ENDCASE
@@ -99,6 +113,7 @@ PROCEDURE Main()
 
    sr_StartLog(nConnection)
 
+   ForcaCollation()
    MostraAmbiente()
    CriaTabela()
    CriaIndices()
@@ -123,6 +138,35 @@ PROCEDURE Main()
 RETURN
 
 //--------------------------------------------------------------------
+// Converte SR_MGMNTINDEXES para a collation pedida em --forcecs.
+// O catalogo ja existe neste ponto: SR_SetEnvSQLRDD o cria na conexao.
+
+STATIC PROCEDURE ForcaCollation()
+
+   LOCAL oCnn := SR_GetConnection()
+   LOCAL cCharset
+   LOCAL nPos
+
+   IF Empty(s_COLLATION)
+      RETURN
+   ENDIF
+
+   // O charset e o primeiro segmento do nome da collation
+   // (utf8mb4_general_ci => utf8mb4, latin1_swedish_ci => latin1)
+
+   nPos := At("_", s_COLLATION)
+   cCharset := IIf(nPos == 0, s_COLLATION, Left(s_COLLATION, nPos - 1))
+
+   ? ""
+   ? "Convertendo SR_MGMNTINDEXES para " + cCharset + " / " + s_COLLATION + " ..."
+
+   oCnn:Exec("alter table SR_MGMNTINDEXES convert to character set " + ;
+             cCharset + " collate " + s_COLLATION, .T.)
+   oCnn:Commit()
+
+RETURN
+
+//--------------------------------------------------------------------
 // Versao do servidor, charset da conexao e collation do IDXCOL_
 
 STATIC PROCEDURE MostraAmbiente()
@@ -130,6 +174,8 @@ STATIC PROCEDURE MostraAmbiente()
    LOCAL oCnn := SR_GetConnection()
    LOCAL aRes := {}
    LOCAL aRow
+   LOCAL cCollCnn := ""
+   LOCAL cCollCol := ""
 
    ? ""
    ? "=============================================================="
@@ -153,7 +199,8 @@ STATIC PROCEDURE MostraAmbiente()
    aRes := {}
    oCnn:Exec("show variables like 'collation_connection'", .F., .T., @aRes)
    FOR EACH aRow IN aRes
-      ? "collation_connection         : " + AllTrim(SR_Val2Char(aRow[2]))
+      cCollCnn := AllTrim(SR_Val2Char(aRow[2]))
+      ? "collation_connection         : " + cCollCnn
    NEXT
 
    // Collation real da coluna IDXCOL_ no catalogo
@@ -165,9 +212,24 @@ STATIC PROCEDURE MostraAmbiente()
              "and COLUMN_NAME = 'IDXCOL_'", .F., .T., @aRes)
 
    IF Len(aRes) > 0
-      ? "IDXCOL_ charset / collation  : " + AllTrim(SR_Val2Char(aRes[1, 1])) + " / " + ;
-                                            AllTrim(SR_Val2Char(aRes[1, 2]))
+
+      cCollCol := AllTrim(SR_Val2Char(aRes[1, 2]))
+
+      ? "IDXCOL_ charset / collation  : " + AllTrim(SR_Val2Char(aRes[1, 1])) + " / " + cCollCol
       ? "IDXCOL_ largura declarada    : " + AllTrim(SR_Val2Char(aRes[1, 3])) + " caracteres"
+
+      ? ""
+
+      IF cCollCol == cCollCnn
+         ? ">> Coluna e conexao usam a MESMA collation: a largura e calculada"
+         ? "   corretamente e este ambiente nao deve reproduzir o erro."
+         ? "   Use --forcecs <outra collation> para provocar a diferenca."
+      ELSE
+         ? ">> Coluna e conexao usam collations DIFERENTES (" + cCollCol + " x " + cCollCnn + ")."
+         ? "   E nesta condicao que a largura da coluna passa a ser contada"
+         ? "   em bytes. Veja abaixo o comprimento com que o IDXCOL_ chega."
+      ENDIF
+
    ELSE
       ? "IDXCOL_                      : SR_MGMNTINDEXES ainda nao existe"
    ENDIF

--- a/tests/mysql/testindkeypad.prg
+++ b/tests/mysql/testindkeypad.prg
@@ -42,6 +42,21 @@
 // Com a conexao em utf8mb4_0900_ai_ci isso da a mesma largura de 12 que
 // o Mario reportou. Use --forcecs utf8mb4_0900_ai_ci para voltar ao caso
 // que funciona e comparar.
+//
+// NOTA: o efeito do --forcecs depende da biblioteca cliente. As libmysql
+// modernas recebem os metadados ja convertidos para a collation da
+// conexao, entao a divisao e aplicada e o IDXCOL_ chega com 3 mesmo com
+// as collations diferentes. Nesse caso use a opcao abaixo.
+//
+// Opcao --forcewidth <n>: alarga IDXCOL_ para CHAR(n) no catalogo. Isso
+// reproduz o EFEITO do bug de forma deterministica em qualquer driver:
+// o valor passa a chegar preenchido com espacos ate n, exatamente como
+// chega no ambiente do Mario, sem depender do comportamento da lib
+// cliente. Com uma lib SEM a normalizacao do IDXCOL_ a abertura falha
+// com "Index Column not Found - INDKEY_001"; com a lib corrigida abre
+// normalmente:
+//
+//   testindkeypad ... --forcewidth 12
 
 #ifdef __XHARBOUR__
 #xtranslate HB_PVALUE([<x,...>]) => PVALUE(<x>)
@@ -69,6 +84,7 @@ STATIC s_DTB    := "dbtest"
 
 STATIC s_nPad := 0      // largura com que IDXCOL_ voltou do driver
 STATIC s_COLLATION := ""   // --forcecs
+STATIC s_nForceW := 0      // --forcewidth
 
 PROCEDURE Main()
 
@@ -88,6 +104,7 @@ PROCEDURE Main()
       CASE HB_PValue(n) == "--dtb"    ; s_DTB := HB_PValue(++n)
       CASE HB_PValue(n) == "--keep"   ; lKeep := .T.
       CASE HB_PValue(n) == "--forcecs"; s_COLLATION := HB_PValue(++n)
+      CASE HB_PValue(n) == "--forcewidth"; s_nForceW := Val(HB_PValue(++n))
       OTHERWISE
          ? "Parametro desconhecido:", HB_PValue(n)
       ENDCASE
@@ -114,6 +131,7 @@ PROCEDURE Main()
    sr_StartLog(nConnection)
 
    ForcaCollation()
+   ForcaLargura()
    MostraAmbiente()
    CriaTabela()
    CriaIndices()
@@ -162,6 +180,28 @@ STATIC PROCEDURE ForcaCollation()
 
    oCnn:Exec("alter table SR_MGMNTINDEXES convert to character set " + ;
              cCharset + " collate " + s_COLLATION, .T.)
+   oCnn:Commit()
+
+RETURN
+
+//--------------------------------------------------------------------
+// Alarga IDXCOL_ para CHAR(n): o driver passa a reportar essa largura e
+// o valor chega preenchido com espacos, reproduzindo o efeito do bug em
+// qualquer biblioteca cliente
+
+STATIC PROCEDURE ForcaLargura()
+
+   LOCAL oCnn := SR_GetConnection()
+
+   IF s_nForceW <= 3
+      RETURN
+   ENDIF
+
+   ? ""
+   ? "Alargando IDXCOL_ para CHAR(" + AllTrim(Str(s_nForceW)) + ") ..."
+
+   oCnn:Exec("alter table SR_MGMNTINDEXES modify IDXCOL_ char(" + ;
+             AllTrim(Str(s_nForceW)) + ")", .T.)
    oCnn:Commit()
 
 RETURN
@@ -387,6 +427,7 @@ STATIC PROCEDURE MedePadding()
       ? "  >> Nenhum registro sintetico encontrado no catalogo."
    ELSE
       ? "  >> Sem padding (len = 3). Este ambiente NAO reproduz o erro."
+      ? "  >> Para simular o efeito em qualquer driver, rode com --forcewidth 12"
    ENDIF
 
 RETURN
@@ -471,7 +512,8 @@ STATIC PROCEDURE Veredito(lFalhou)
 
    OTHERWISE
       ? "OK, porem sem padding neste ambiente - o teste nao exercitou o problema."
-      ? "Veja no README como forcar a diferenca de charset no catalogo."
+      ? "Rode novamente com --forcewidth 12 para simular o efeito do bug"
+      ? "independente da biblioteca cliente."
 
    ENDCASE
 


### PR DESCRIPTION
Fixes the error reported by Mario Sabado on native MySQL connections:

    Error SQLRDD/18  Index Column not Found - INDKEY_001  Table : ARBANK

## Root cause

IDXCOL_ in SR_MGMNTINDEXES is CHAR(3), and the name of a synthetic index
column is built by concatenation:

    aCols := {"INDKEY_" + ::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS]}

then looked up with ==, which in Harbour requires both strings to have
the same length. This only works while the driver returns IDXCOL_ with
exactly 3 characters.

The native MySQL driver returns every CHAR value space padded to the
width it computed for the column, and it counts that width in BYTES
whenever the collation id in the result metadata differs from the
connection collation id. A CHAR(3) in utf8mb4 then arrives as
"001" + 9 spaces, the built name becomes "INDKEY_001         ", the
lookup fails and the table cannot be opened. The trailing spaces are
invisible in the error message, which made the reports very confusing -
the name looked correct. ODBC is unaffected because it reports the
declared width, which also matched the reports.

Whether the padding happens depends on the client library the executable
links (modern libs receive metadata already converted to the connection
collation), so it could not be reproduced with a server container alone -
see the reproducer below.

## Fix

Every site that builds the column name now trims at the point of use:

    "INDKEY_" + AllTrim(::aIndexMgmnt[nInd, SR_INDEXMAN_COLUMNS])

covering sqlOpenAllIndexes(), sqlOrderListAdd(), the KEY codeblock
AScan and the UPDATE/INSERT builders in the five variants (generic/ODBC,
MySQL, PostgreSQL, Firebird, Oracle - the pattern is identical in all,
so the defect is latent everywhere). LoadRegisteredTags() additionally
normalizes IDXCOL_ at load time, next to the existing IDXNAME_/TAG_
normalizations, since it also feeds SR_INDEXMAN_SYNTH_COLPOS and the
cached copy in oSql:aTableInfo.

Trimming only at load time is not enough: sqlOrderCreate() reloads
::aIndexMgmnt with direct SELECTs and sqlOrderListAdd() can run over that
raw state - the reproducer showed the error firing during INDEX ON.

No database change and no index recreation needed.

## Reproducer

tests/mysql/testindkeypad.prg replicates the reported sequence (bag with
two tags, classic synthetic path, USE / SET INDEX TO ADDITIVE / SET ORDER
TO TAG), prints the length IDXCOL_ arrives with and the collation pair,
and reports a verdict. Since the padding depends on the client library,
--forcewidth 12 widens IDXCOL_ to CHAR(12), which reproduces the padded
value deterministically on any driver. --forcecs <collation> converts the
catalog table to a chosen collation for charset experiments.

Verified against MySQL 9.7.1 (Docker): before the fix, --forcewidth 12
reproduces the exact reported error during INDEX ON; after the fix, the
same run creates and opens the indexes normally with the driver still
delivering IDXCOL_ 12 wide. All five variants compile clean and the
generic, MySQL and PostgreSQL libraries build clean with MSVC 2022.
